### PR TITLE
fix(docker): do not assign port

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -4,8 +4,5 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     command: sleep infinity
-    ports:
-      - "4000"
-      - "35729:35729"
     volumes:
       - ..:/usr/src/calitp


### PR DESCRIPTION
Removed port assignment in compose.yml, so that Devcontainer runs properly.

This PR could conceivably go into `main`, but for ease of branch management, I'm opting to put this into `staging`.