### PR TITLE
Refactor: Remove article, constricted and use Bootstrap instead

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -5,6 +5,8 @@
   </head>
 
   <body>
-    {% include header.html %} {{content}} {% include footer.html %}
+    {% include header.html %}
+    <main class="container">{{content}}</main>
+    {% include footer.html %}
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -3,344 +3,315 @@ title: "Example"
 layout: default
 ---
 
-<article>
-  <section id="deck">
+<section id="deck">
+  <section>
+    <h1>A modern and consistent transportation experience throughout California</h1>
+    <p class="big">
+      Learn how the California Integrated Travel Project (Cal-ITP) is making riding by rail and bus simpler and more
+      cost-effective—for providers and riders.
+    </p>
+  </section>
+
+  <picture>
+    <img
+      id="triforce"
+      src="images/hero-header.png"
+      alt="A trio of images, clockwise from top: a bus, a train platform with a sign that announces “Next train in 3 minutes,” and a transit rider paying their fare by tapping their smartphone’s mobile wallet on a payment reader when boarding"
+    />
+  </picture>
+</section>
+
+<section id="details">
+  <section id="enabling-contactless-payment" class="box">
+    <section class="callout">
+      <picture>
+        <img
+          src="images/enabling-contactless-payment.png"
+          alt="A trio of images, from left to right: a contactless-enabled bank card, a mobile wallet on a smartphone, and a mobile wallet on a smartwatch"
+          width="142"
+        />
+      </picture>
+      <section class="right-callout">
+        <h3>Enabling contactless payments</h3>
+        <p>
+          Adding a contactless payment reader to a bus or train means customers can quickly and easily tap to pay as they board
+          with the bank card or smartphone that’s already in their pocket—just like they’d tap to buy a coffee.
+        </p>
+        <p>
+          Starting with
+          <a
+            href="https://mst.org/news_items/monterey-salinas-transit-announces-launch-of-contactless-fare-payment-demonstration/"
+            rel="noreferrer"
+            target="_blank"
+            >Monterey-Salinas Transit</a
+          >, Cal-ITP and partners like Visa are demonstrating how a transit provider that has traditionally used cash and
+          agency-specific fare cards can accept contactless bank card payments like any other merchant.
+        </p>
+        <p>
+          And to make it easier and more affordable for public transportation providers anywhere in the U.S. to acquire the
+          building blocks of contactless payments, the California Department of General Services (DGS)—in collaboration with
+          Cal-ITP—conducted a Request for Proposal that established Master Service Agreements (MSAs) allowing public
+          transportation providers to purchase contactless payments hardware and software directly from vendors without further
+          competitive bidding. Learn about the MSAs in our
+          <a href="{{ site.baseurl }}/assets/Contactless.Payments.MSA.pdf" target="_blank">press release</a>, and
+          <a href="https://www.camobilitymarketplace.org/contracts" target="_blank">view the MSAs</a>.
+        </p>
+      </section>
+    </section>
+  </section>
+
+  <section id="automating-customer-discounts" class="box">
+    <section class="callout">
+      <picture>
+        <img src="images/automating-customer-discounts.png" alt="Checking a state-issued identification" width="131" />
+      </picture>
+      <section class="right-callout">
+        <h3>Automating customer discounts</h3>
+        <p>
+          Our <a rel="noreferrer" target="_blank" href="https://benefits.calitp.org">Cal-ITP Benefits</a> web application
+          streamlines the process for transit riders to instantly qualify for and receive discounts, starting with
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://mst.org/news_items/monterey-salinas-transit-mst-announces-discount-contactless-fares-for-both-local-and-visiting-riders-65-with-launch-of-new-benefits-eligibility-verification-website/"
+            >Monterey-Salinas Transit</a
+          >
+          (MST), which offers a half-price Senior Fare. Now older adults (65+) who are able to
+          <a
+            href="https://login.gov/help/verify-your-identity/how-to-verify-your-identity/#requirements-for-identity-verification"
+            target="_blank"
+            >electronically verify their identity</a
+          >
+          are able to access MST's reduced fares without the hassle of paperwork.
+        </p>
+        <p>
+          We worked with state partners on this product launch, and next we're working to bring youth, lower-income riders,
+          veterans, people with disabilities, and others the same instant access to free or reduced fares across all California
+          transit providers, without having to prove eligibility to each agency.
+        </p>
+      </section>
+    </section>
+  </section>
+
+  <section id="standardizing-trip-quality" class="box">
+    <section class="callout">
+      <picture>
+        <img
+          src="images/standardizing-trip-quality.png"
+          alt="A bus that transits real-time arrival and departure information"
+          width="106"
+        />
+      </picture>
+      <section class="right-callout">
+        <h3>Standardizing information for easy trip planning</h3>
+        <p>
+          Cal-ITP is helping transit providers remove the guesswork for riders wondering when the next bus or train will arrive or
+          if they’ll make their connection by using the General Transit Feed Specification (GTFS)—the global standard for
+          publishing transit information. Cal-ITP developed
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
+            >California Minimum GTFS Guidelines</a
+          >
+          and is working to ensure statewide GTFS static coverage by the end of 2020 and GTFS Realtime by the end of 2021. Along
+          the way, the Cal-ITP team will support transit providers by assessing their systems and providing technical assistance
+          so riders can easily access complete, accurate, consistent, and timely mobility data for their journey.
+        </p>
+      </section>
+    </section>
+  </section>
+</section>
+
+<section id="about" class="constricted">
+  <h2>Bringing industry standards to California’s transit providers</h2>
+  <p class="important">
+    There are hundreds of public transit providers in California—with no single system for collecting fares, verifying eligibility
+    for fare discounts, or providing up-to-date vehicle arrival information to riders.
+  </p>
+  <p class="important">
+    This lack of uniformity creates barriers for new riders, complicates travel across different systems, and increases expenses
+    for individual providers.
+  </p>
+  <p>
+    Supported by the
+    <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/">California State Transportation Agency</a>
+    (CalSTA) and the
+    <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ ">California Department of Transportation</a>
+    (Caltrans) through a grant from the
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="blue-link"
+      href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
+      >California Transit and Intercity Rail Capital Program</a
+    >
+    (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
+    cost-effective for everyone.
+  </p>
+  <p>Since forming in 2018, some Cal-ITP milestones include:</p>
+
+  <h2>Identifying solutions</h2>
+  <p>
+    In August 2019, CalSTA and Caltrans organized a market sounding kickoff with companies and organizations in the payments,
+    banking, and trip-planning industries. In that meeting, barriers to seamless trip planning and fare payment were identified,
+    such as the lack of uniformity among California’s transit providers. Cal-ITP’s
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="purple-link"
+      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/final-cal-itp-market-sounding-market-response-summary-103119b-a11y.pdf"
+      >1st Market Sounding</a
+    >
+    in October 2019 dug into these barriers and identified specific opportunities for Cal-ITP to assist California’s transit
+    providers by leveraging global standards for data and payment systems.
+  </p>
+
+  <h2>Understanding feasibility</h2>
+  <p>
+    Following the market sounding, Cal-ITP conducted a more thorough analysis to assess the financial and economic impacts of the
+    recommended initiatives. The April 2020
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="red-link"
+      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-feasibility-study-042420-a11y.pdf"
+      >Cal-ITP Feasibility Study</a
+    >
+    details the state of public transit in California and quantifies the economic benefits of Cal-ITP’s three primary initiatives
+    under conservative to moderate assumptions of project costs and ridership effects based on estimated demand.
+  </p>
+
+  <h2>Getting to work</h2>
+  <p>
+    To increase the quality and quantity of transit data published by California's transit providers, Cal-ITP and state and
+    regional partners explored passenger-counting technologies in July 2020. Passenger occupancy data is crucial for
+    transportation planning purposes, and physical distancing due to COVID-19 has highlighted the benefit for riders to know
+    real-time passenger crowding in trip planning. Cal-ITP’s
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="gold-link"
+      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-market-sounding-real-time-transit-vehicle-occupancy-report-a11y.pdf"
+      >2nd Market Sounding: Real-Time Transit Vehicle Occupancy Report</a
+    >
+    was published in October 2020.
+  </p>
+
+  <p>
+    In 2020, Cal-ITP and partners gathered input from marketplace companies to gauge capabilities and interest in supporting
+    payment issuance. The findings were documented in Cal-ITP’s
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="green-link"
+      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/cal-itp-payment-issuance-market-sounding-response-summary-report-final-a11y.pdf"
+      >3rd Market Sounding Report: Payment Issuance for California Transit</a
+    >
+    and led to Cal-ITP collaborating with the California Air Resources Board (CARB) in 2021 to understand the market for mobility
+    accounts. Highlights from interviews with companies, transit agencies, and nonprofit and academic stakeholders can be found in
+    the
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="blue-link"
+      href="{{ site.baseurl }}/assets/Mobility.Accounts.Market.Sounding.Summary.Report.pdf"
+      >Market Sounding Report: Mobility Accounts</a
+    >.
+  </p>
+
+  <p>
+    Throughout 2021, Cal-ITP forged new partnerships and live-tested solutions, advancing our vision across our three primary
+    project areas. Check out our
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="purple-link"
+      href="{{ site.baseurl }}/assets/Cal-ITP.2021.Accomplishments.Report.pdf"
+      >2021 Accomplishments Report</a
+    >
+    for complete details on our contactless payment demonstration projects and other ways in which our teams tackled mobility
+    service data, payment acceptance, and eligibility for discounts and benefits.
+  </p>
+
+  <p>
+    In March 2022, Cal-ITP announced its
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="red-link"
+      href="{{ site.baseurl }}/assets/Cal-ITP.Market.Consultation.Benefits.Administrator.pdf"
+      >Market Consultation: Benefits Administrator</a
+    >, inviting companies to contribute answers to a set of five questions that could shape the way that California residents
+    qualify for and receive benefits, starting with transit discounts.
+  </p>
+
+  <p>
+    In June 2022, Cal-ITP announced a
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="gold-link"
+      href="{{ site.baseurl }}/assets/Cal-ITP.Open.Data.Standard.Improve.Transit.Agency.Operations.pdf"
+      >new open data standard</a
+    >
+    to improve transit agency operations and promote an interoperable transit ecosystem by improving the flow of data and
+    information sharing. The Operational Data Standard (ODS) leverages the existing GTFS standard used by transit agencies and
+    riders all over the world for transit service information and extends it to include data about personnel, scheduled
+    maintenance, and non-revenue service. The ODS specification is a product of the Operational Data Standard Working Group, a
+    coalition of more than 40 transit agencies, transit technology vendors such as computer-aided dispatch/automatic vehicle
+    location (CAD/AVL) companies, transit scheduling companies, and other contributors.
+  </p>
+</section>
+
+<picture class="railway">
+  <img
+    id="tracks-1"
+    src="images/tracks-divider-1.png"
+    alt="Decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
+
+<section id="funfacts" class="constricted">
+  <h2>Helping California achieve critical goals through transportation</h2>
+  <p class="important">
+    Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success stories
+    from transit providers around the world.
+  </p>
+
+  <section id="facts">
+    <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
     <section>
-      <h1>A modern and consistent transportation experience throughout California</h1>
-      <p class="big">
-        Learn how the California Integrated Travel Project (Cal-ITP) is making riding by rail and bus simpler and more
-        cost-effective—for providers and riders.
-      </p>
+      <h3>Improve the customer experience</h3>
     </section>
 
-    <picture>
-      <img
-        id="triforce"
-        src="images/hero-header.png"
-        alt="A trio of images, clockwise from top: a bus, a train platform with a sign that announces “Next train in 3 minutes,” and a transit rider paying their fare by tapping their smartphone’s mobile wallet on a payment reader when boarding"
-      />
-    </picture>
-  </section>
-
-  <section id="details">
-    <section id="enabling-contactless-payment" class="box">
-      <section class="callout">
-        <picture>
-          <img
-            src="images/enabling-contactless-payment.png"
-            alt="A trio of images, from left to right: a contactless-enabled bank card, a mobile wallet on a smartphone, and a mobile wallet on a smartwatch"
-            width="142"
-          />
-        </picture>
-        <section class="right-callout">
-          <h3>Enabling contactless payments</h3>
-          <p>
-            Adding a contactless payment reader to a bus or train means customers can quickly and easily tap to pay as they board
-            with the bank card or smartphone that’s already in their pocket—just like they’d tap to buy a coffee.
-          </p>
-          <p>
-            Starting with
-            <a
-              href="https://mst.org/news_items/monterey-salinas-transit-announces-launch-of-contactless-fare-payment-demonstration/"
-              rel="noreferrer"
-              target="_blank"
-              >Monterey-Salinas Transit</a
-            >, Cal-ITP and partners like Visa are demonstrating how a transit provider that has traditionally used cash and
-            agency-specific fare cards can accept contactless bank card payments like any other merchant.
-          </p>
-          <p>
-            And to make it easier and more affordable for public transportation providers anywhere in the U.S. to acquire the
-            building blocks of contactless payments, the California Department of General Services (DGS)—in collaboration with
-            Cal-ITP—conducted a Request for Proposal that established Master Service Agreements (MSAs) allowing public
-            transportation providers to purchase contactless payments hardware and software directly from vendors without further
-            competitive bidding. Learn about the MSAs in our
-            <a href="{{ site.baseurl }}/assets/Contactless.Payments.MSA.pdf" target="_blank">press release</a>, and
-            <a href="https://www.camobilitymarketplace.org/contracts" target="_blank">view the MSAs</a>.
-          </p>
-        </section>
-      </section>
+    <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
+    <section>
+      <h3>Increase transit ridership</h3>
     </section>
 
-    <section id="automating-customer-discounts" class="box">
-      <section class="callout">
-        <picture>
-          <img src="images/automating-customer-discounts.png" alt="Checking a state-issued identification" width="131" />
-        </picture>
-        <section class="right-callout">
-          <h3>Automating customer discounts</h3>
-          <p>
-            Our <a rel="noreferrer" target="_blank" href="https://benefits.calitp.org">Cal-ITP Benefits</a> web application
-            streamlines the process for transit riders to instantly qualify for and receive discounts, starting with
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href="https://mst.org/news_items/monterey-salinas-transit-mst-announces-discount-contactless-fares-for-both-local-and-visiting-riders-65-with-launch-of-new-benefits-eligibility-verification-website/"
-              >Monterey-Salinas Transit</a
-            >
-            (MST), which offers a half-price Senior Fare. Now older adults (65+) who are able to
-            <a
-              href="https://login.gov/help/verify-your-identity/how-to-verify-your-identity/#requirements-for-identity-verification"
-              target="_blank"
-              >electronically verify their identity</a
-            >
-            are able to access MST's reduced fares without the hassle of paperwork.
-          </p>
-          <p>
-            We worked with state partners on this product launch, and next we're working to bring youth, lower-income riders,
-            veterans, people with disabilities, and others the same instant access to free or reduced fares across all California
-            transit providers, without having to prove eligibility to each agency.
-          </p>
-        </section>
-      </section>
+    <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
+    <section>
+      <h3>Lower costs for transit providers and riders</h3>
     </section>
 
-    <section id="standardizing-trip-quality" class="box">
-      <section class="callout">
-        <picture>
-          <img
-            src="images/standardizing-trip-quality.png"
-            alt="A bus that transits real-time arrival and departure information"
-            width="106"
-          />
-        </picture>
-        <section class="right-callout">
-          <h3>Standardizing information for easy trip planning</h3>
-          <p>
-            Cal-ITP is helping transit providers remove the guesswork for riders wondering when the next bus or train will arrive
-            or if they’ll make their connection by using the General Transit Feed Specification (GTFS)—the global standard for
-            publishing transit information. Cal-ITP developed
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
-              >California Minimum GTFS Guidelines</a
-            >
-            and is working to ensure statewide GTFS static coverage by the end of 2020 and GTFS Realtime by the end of 2021. Along
-            the way, the Cal-ITP team will support transit providers by assessing their systems and providing technical assistance
-            so riders can easily access complete, accurate, consistent, and timely mobility data for their journey.
-          </p>
-        </section>
-      </section>
+    <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
+    <section>
+      <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
     </section>
   </section>
+</section>
 
-  <section id="about" class="constricted">
-    <h2>Bringing industry standards to California’s transit providers</h2>
-    <p>
-      There are hundreds of public transit providers in California—with no consistent way to collect fares, verify eligibility for
-      fare discounts, or provide real-time vehicle information to customers on their phones.
-    </p>
-    <p>
-      The lack of a consistent experience creates barriers for new customers, complicates travel across different systems, and
-      increases expenses for individual providers.
-    </p>
-    <p>
-      Supported by the
-      <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/"
-        >California State Transportation Agency</a
-      >
-      (CalSTA) and the
-      <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ "
-        >California Department of Transportation</a
-      >
-      (Caltrans) through a grant from the
-      <a
-        rel="noreferrer"
-        target="_blank"
-        class="blue-link"
-        href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
-        >California Transit and Intercity Rail Capital Program</a
-      >
-      (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
-      cost-effective for everyone.
-    </p>
-  </section>
+<picture class="railway">
+  <img
+    id="tracks-2"
+    src="images/tracks-divider-2.png"
+    alt="Another decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
 
-  <picture class="railway">
-    <img
-      id="tracks-1"
-      src="images/tracks-divider-1.png"
-      alt="Decorative element with dots and dashes, meant to resemble a transit map"
-    />
-  </picture>
-
-  <section id="funfacts" class="constricted">
-    <h2>Helping California achieve critical goals through transportation</h2>
-    <p class="important">
-      Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success
-      stories from transit providers around the world.
-    </p>
-
-    <section id="facts">
-      <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
-      <section>
-        <h3>Improve the customer experience</h3>
-        <p>
-          <strong>Real-time global data standards save time—and change perceptions of wait time.</strong> In Seattle, riders with
-          access to GTFS Realtime information perceived their transit wait times as
-          <a rel="noreferrer" target="_blank" href="https://www.sciencedirect.com/science/article/abs/pii/S0965856411001030"
-            >30% shorter than those without GTFS Realtime. Actual wait times were reduced by 2 minutes.</a
-          >
-        </p>
-        <p>
-          <strong>Contactless fare payments make transit easier for riders—especially tourists.</strong> Since beginning to accept
-          contactless payments in 2019, New York City has seen
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://www.masstransitmag.com/technology/fare-collection/fare-collection-equipment/press-release/21127945/mta-headquarters-mtas-omny-coming-to-all-manhattan-local-buses-and-more-subway-stations"
-            >taps from 130 countries</a
-          >
-          and eliminated the trip delay for currency conversion or to buy a fare card.
-        </p>
-        <p>
-          <strong>Contactless payments are popular with riders and boost satisfaction.</strong> In London,
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://www.mastercard.us/content/dam/mccom/en-us/documents/ContactlessTFLLondonCaseStudy.pdf"
-            >2/3 of riders converted to contactless payments after just their first use</a
-          >. And in a recent survey of UK commuters,
-          <a rel="noreferrer" target="_blank" href="https://www.ukfinance.org.uk/system/files/Contactless%20Transit_v4_FINAL.pdf"
-            >45% of respondents said they would feel more positive toward public transit if they could use contactless payments</a
-          >.
-        </p>
-      </section>
-
-      <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
-      <section>
-        <h3>Increase transit ridership</h3>
-        <p>
-          <strong>Contactless payments are an incentive for riders to return to transit after the COVID-19 pandemic.</strong>
-          According to Visa,
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://usa.visa.com/visa-everywhere/blog/bdp/2020/07/14/transit-riders-are-1594762921880.html"
-            >contactless transactions for transit increased by 187% from April to June 2020</a
-          >.
-        </p>
-        <p>
-          <strong>Convenient, universal fare payments grow ridership.</strong> Riders are more likely to use transit when they
-          don’t need to think about how they’ll pay their fare. In its first year accepting contactless payments,
-          <a rel="noreferrer" target="_blank" href="http://content.tfl.gov.uk/board-160203-item05-commissioners-report-v2.pdf"
-            >London saw a 4%–5% growth in Underground ridership</a
-          >.
-        </p>
-        <p>
-          <strong>Real-time arrival information shows that transit is a reliable way to commute and travel.</strong> The
-          introduction of
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://rmi.org/wp-content/uploads/2017/03/consortium_approach_to_ITD_report2016.pdf"
-            >real-time arrival information increased bus ridership by about 2% in New York and Chicago</a
-          >.
-        </p>
-      </section>
-
-      <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
-      <section>
-        <h3>Lower costs for transit providers and riders</h3>
-        <p>
-          <strong>Cash alternatives will cut costs for transit providers.</strong> Washington, D.C., spends 10¢ per dollar
-          collecting cash fares but
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://s3.us-east-1.amazonaws.com/rpa-org/pdfs/TLS-WP-Fare-Collection-and-Fare-Policy.pdf"
-            >just 4¢ per dollar on credit/debit card fares</a
-          >.
-        </p>
-        <p>
-          <strong>Digital payments are less expensive to accept.</strong> According to Visa, the average merchant spends about 7¢
-          per dollar on processing cash and checks versus
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://usa.visa.com/dam/VCOM/global/visa-everywhere/documents/visa-cashless-cities-report.pdf"
-            >5¢ per dollar for contactless payments</a
-          >.
-        </p>
-        <p>
-          <strong>Machine maintenance and ticketing fees decrease.</strong> In New York City, the MTA expects to
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://gothamist.com/news/omny-is-alive-mta-opens-up-tap-payment-system-in-limited-subway-pilot"
-            >save millions of dollars by eliminating the costs required for upkeep of its MetroCard system</a
-          >.
-        </p>
-      </section>
-
-      <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
-      <section>
-        <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
-        <p>
-          <strong>Contactless payments decrease bus dwell times.</strong>
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://www.energy.ca.gov/data-reports/energy-almanac/transportation-energy/public-transit-california"
-            >Buses make up 62% of California’s urban public transit trips</a
-          >. The Transportation Research Board found that
-          <a rel="noreferrer" target="_blank" href="http://www.trb.org/Main/Blurbs/169437.aspx"
-            >bus boarding times are almost cut in half when tapping</a
-          >
-          (2.75 seconds per passenger) compared to swiping (5.0 seconds per passenger) or paying cash (4.5 seconds per passenger).
-        </p>
-        <p>
-          <strong>Making transit more attractive to riders will reduce driving demand.</strong>
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://data.census.gov/cedsci/table?t=Commuting&tid=ACSST1Y2019.S0801&hidePreview=false"
-            >California’s transit mode share</a
-          >
-          (5.2%) is comparable to the
-          <a
-            rel="noreferrer"
-            target="_blank"
-            href="https://data.census.gov/cedsci/table?t=Commuting&tid=ACSST1Y2019.S0801&hidePreview=false"
-            >national average</a
-          >
-          (5.0%). However, given our state’s density, diversity, congestion, and size, travel by bus and rail can and should be
-          higher in California. Contactless fare payments and real-time arrival information lead to higher transit ridership,
-          mitigating congestion and reducing greenhouse gas emissions.
-        </p>
-      </section>
-
-      <picture><img id="goal-5" src="images/number-5.png" alt="Number 5" /></picture>
-      <section>
-        <h3>Promote equitable access to transportation across the state’s transit providers</h3>
-        <p>
-          <strong
-            >A statewide program to verify eligibility for reduced fares will alleviate cumbersome processes for both transit
-            providers and riders.</strong
-          >
-          A simple, digitized, statewide verification program will enable any rider to have their eligibility for a reduced-fare
-          program instantly verified for any transit provider in California. This way, older adults, students, veterans, and
-          others can ride transit anywhere in the state with the confidence that they’ll be charged the right fare every time.
-        </p>
-        <p>
-          <strong>Fare capping reduces transit costs for low-income riders.</strong> Unlimited-ride passes cost more upfront,
-          forcing many riders to pay as they go at full fare. Contactless fare collection enables “fare capping,” which allows
-          riders to pay the unlimited-ride price over time. This means that, after tapping enough times to reach the cost of a
-          daily, weekly, or monthly pass, riders will no longer be charged for transit use for the remainder of that time period.
-        </p>
-      </section>
-    </section>
-  </section>
-
-  <picture class="railway">
-    <img
-      id="tracks-2"
-      src="images/tracks-divider-2.png"
-      alt="Another decorative element with dots and dashes, meant to resemble a transit map"
-    />
-  </picture>
-
-  <section id="reachout" class="constricted">
+<section id="reachout" class="constricted">
+  <div class="col-6">
     <h2>The time is now—reach out to help and to learn more</h2>
     <p>This initiative is critical now more than ever.</p>
     <p>
@@ -366,45 +337,44 @@ layout: default
       government, public and private transit providers, academia, and think tanks, as well as vendors of relevant technologies and
       business models. Join us.
     </p>
-  </section>
+  </div>
+</section>
 
-  <section id="lastminute">
-    <section id="connect" class="box">
-      <section class="blob">
-        <picture
-          ><img
-            src="images/connect.png"
-            alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
-            width="80"
-        /></picture>
-        <h3>Connect with Cal-ITP</h3>
-        <p>Drop us a line at <a rel="noreferrer" target="_blank" href="mailto:hello@calitp.org">hello@calitp.org</a> to</p>
-        <ul>
-          <li>request technical assistance</li>
-          <li>get more information</li>
-          <li>offer collaborative support</li>
-          <li>join our email list for updates</li>
-        </ul>
-      </section>
-    </section>
-
-    <section id="update" class="box">
-      <section class="blob">
-        <picture
-          ><img
-            src="images/stay-up-to-date.png"
-            alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
-            width="80"
-        /></picture>
-        <h3>Stay up to date</h3>
-        <p>
-          See our <a href="https://dot.ca.gov/cal-itp" rel="noreferrer" target="_blank">latest milestones</a>, and subscribe to
-          the
-          <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website" rel="noreferrer" target="_blank"
-            >Caltrans Mobility Newsletter</a
-          >, a free biweekly resource with frequent Cal-ITP project updates.
-        </p>
-      </section>
+<section id="lastminute">
+  <section id="connect" class="box">
+    <section class="blob">
+      <picture
+        ><img
+          src="images/connect.png"
+          alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
+          width="80"
+      /></picture>
+      <h3>Connect with Cal-ITP</h3>
+      <p>Drop us a line at <a rel="noreferrer" target="_blank" href="mailto:hello@calitp.org">hello@calitp.org</a> to</p>
+      <ul>
+        <li>request technical assistance</li>
+        <li>get more information</li>
+        <li>offer collaborative support</li>
+        <li>join our email list for updates</li>
+      </ul>
     </section>
   </section>
-</article>
+
+  <section id="update" class="box">
+    <section class="blob">
+      <picture
+        ><img
+          src="images/stay-up-to-date.png"
+          alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
+          width="80"
+      /></picture>
+      <h3>Stay up to date</h3>
+      <p>
+        See our <a href="https://dot.ca.gov/cal-itp" rel="noreferrer" target="_blank">latest milestones</a>, and subscribe to the
+        <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website" rel="noreferrer" target="_blank"
+          >Caltrans Mobility Newsletter</a
+        >, a free biweekly resource with frequent Cal-ITP project updates.
+      </p>
+    </section>
+  </section>
+</section>

--- a/src/index.html
+++ b/src/index.html
@@ -123,145 +123,151 @@ layout: default
   </section>
 </section>
 
-<section id="about" class="constricted">
-  <h2>Bringing industry standards to California’s transit providers</h2>
-  <p class="important">
-    There are hundreds of public transit providers in California—with no single system for collecting fares, verifying eligibility
-    for fare discounts, or providing up-to-date vehicle arrival information to riders.
-  </p>
-  <p class="important">
-    This lack of uniformity creates barriers for new riders, complicates travel across different systems, and increases expenses
-    for individual providers.
-  </p>
-  <p>
-    Supported by the
-    <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/">California State Transportation Agency</a>
-    (CalSTA) and the
-    <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ ">California Department of Transportation</a>
-    (Caltrans) through a grant from the
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="blue-link"
-      href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
-      >California Transit and Intercity Rail Capital Program</a
-    >
-    (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
-    cost-effective for everyone.
-  </p>
-  <p>Since forming in 2018, some Cal-ITP milestones include:</p>
+<section id="about" class="row justify-content-center">
+  <div class="col-lg-6 col-md-8 col-12">
+    <h2>Bringing industry standards to California’s transit providers</h2>
+    <p class="important">
+      There are hundreds of public transit providers in California—with no single system for collecting fares, verifying
+      eligibility for fare discounts, or providing up-to-date vehicle arrival information to riders.
+    </p>
+    <p class="important">
+      This lack of uniformity creates barriers for new riders, complicates travel across different systems, and increases expenses
+      for individual providers.
+    </p>
+    <p>
+      Supported by the
+      <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/"
+        >California State Transportation Agency</a
+      >
+      (CalSTA) and the
+      <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ "
+        >California Department of Transportation</a
+      >
+      (Caltrans) through a grant from the
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="blue-link"
+        href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
+        >California Transit and Intercity Rail Capital Program</a
+      >
+      (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
+      cost-effective for everyone.
+    </p>
+    <p>Since forming in 2018, some Cal-ITP milestones include:</p>
 
-  <h2>Identifying solutions</h2>
-  <p>
-    In August 2019, CalSTA and Caltrans organized a market sounding kickoff with companies and organizations in the payments,
-    banking, and trip-planning industries. In that meeting, barriers to seamless trip planning and fare payment were identified,
-    such as the lack of uniformity among California’s transit providers. Cal-ITP’s
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="purple-link"
-      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/final-cal-itp-market-sounding-market-response-summary-103119b-a11y.pdf"
-      >1st Market Sounding</a
-    >
-    in October 2019 dug into these barriers and identified specific opportunities for Cal-ITP to assist California’s transit
-    providers by leveraging global standards for data and payment systems.
-  </p>
+    <h2>Identifying solutions</h2>
+    <p>
+      In August 2019, CalSTA and Caltrans organized a market sounding kickoff with companies and organizations in the payments,
+      banking, and trip-planning industries. In that meeting, barriers to seamless trip planning and fare payment were identified,
+      such as the lack of uniformity among California’s transit providers. Cal-ITP’s
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="purple-link"
+        href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/final-cal-itp-market-sounding-market-response-summary-103119b-a11y.pdf"
+        >1st Market Sounding</a
+      >
+      in October 2019 dug into these barriers and identified specific opportunities for Cal-ITP to assist California’s transit
+      providers by leveraging global standards for data and payment systems.
+    </p>
 
-  <h2>Understanding feasibility</h2>
-  <p>
-    Following the market sounding, Cal-ITP conducted a more thorough analysis to assess the financial and economic impacts of the
-    recommended initiatives. The April 2020
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="red-link"
-      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-feasibility-study-042420-a11y.pdf"
-      >Cal-ITP Feasibility Study</a
-    >
-    details the state of public transit in California and quantifies the economic benefits of Cal-ITP’s three primary initiatives
-    under conservative to moderate assumptions of project costs and ridership effects based on estimated demand.
-  </p>
+    <h2>Understanding feasibility</h2>
+    <p>
+      Following the market sounding, Cal-ITP conducted a more thorough analysis to assess the financial and economic impacts of
+      the recommended initiatives. The April 2020
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="red-link"
+        href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-feasibility-study-042420-a11y.pdf"
+        >Cal-ITP Feasibility Study</a
+      >
+      details the state of public transit in California and quantifies the economic benefits of Cal-ITP’s three primary
+      initiatives under conservative to moderate assumptions of project costs and ridership effects based on estimated demand.
+    </p>
 
-  <h2>Getting to work</h2>
-  <p>
-    To increase the quality and quantity of transit data published by California's transit providers, Cal-ITP and state and
-    regional partners explored passenger-counting technologies in July 2020. Passenger occupancy data is crucial for
-    transportation planning purposes, and physical distancing due to COVID-19 has highlighted the benefit for riders to know
-    real-time passenger crowding in trip planning. Cal-ITP’s
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="gold-link"
-      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-market-sounding-real-time-transit-vehicle-occupancy-report-a11y.pdf"
-      >2nd Market Sounding: Real-Time Transit Vehicle Occupancy Report</a
-    >
-    was published in October 2020.
-  </p>
+    <h2>Getting to work</h2>
+    <p>
+      To increase the quality and quantity of transit data published by California's transit providers, Cal-ITP and state and
+      regional partners explored passenger-counting technologies in July 2020. Passenger occupancy data is crucial for
+      transportation planning purposes, and physical distancing due to COVID-19 has highlighted the benefit for riders to know
+      real-time passenger crowding in trip planning. Cal-ITP’s
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="gold-link"
+        href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/calitp-market-sounding-real-time-transit-vehicle-occupancy-report-a11y.pdf"
+        >2nd Market Sounding: Real-Time Transit Vehicle Occupancy Report</a
+      >
+      was published in October 2020.
+    </p>
 
-  <p>
-    In 2020, Cal-ITP and partners gathered input from marketplace companies to gauge capabilities and interest in supporting
-    payment issuance. The findings were documented in Cal-ITP’s
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="green-link"
-      href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/cal-itp-payment-issuance-market-sounding-response-summary-report-final-a11y.pdf"
-      >3rd Market Sounding Report: Payment Issuance for California Transit</a
-    >
-    and led to Cal-ITP collaborating with the California Air Resources Board (CARB) in 2021 to understand the market for mobility
-    accounts. Highlights from interviews with companies, transit agencies, and nonprofit and academic stakeholders can be found in
-    the
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="blue-link"
-      href="{{ site.baseurl }}/assets/Mobility.Accounts.Market.Sounding.Summary.Report.pdf"
-      >Market Sounding Report: Mobility Accounts</a
-    >.
-  </p>
+    <p>
+      In 2020, Cal-ITP and partners gathered input from marketplace companies to gauge capabilities and interest in supporting
+      payment issuance. The findings were documented in Cal-ITP’s
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="green-link"
+        href="https://dot.ca.gov/-/media/dot-media/cal-itp/documents/cal-itp-payment-issuance-market-sounding-response-summary-report-final-a11y.pdf"
+        >3rd Market Sounding Report: Payment Issuance for California Transit</a
+      >
+      and led to Cal-ITP collaborating with the California Air Resources Board (CARB) in 2021 to understand the market for
+      mobility accounts. Highlights from interviews with companies, transit agencies, and nonprofit and academic stakeholders can
+      be found in the
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="blue-link"
+        href="{{ site.baseurl }}/assets/Mobility.Accounts.Market.Sounding.Summary.Report.pdf"
+        >Market Sounding Report: Mobility Accounts</a
+      >.
+    </p>
 
-  <p>
-    Throughout 2021, Cal-ITP forged new partnerships and live-tested solutions, advancing our vision across our three primary
-    project areas. Check out our
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="purple-link"
-      href="{{ site.baseurl }}/assets/Cal-ITP.2021.Accomplishments.Report.pdf"
-      >2021 Accomplishments Report</a
-    >
-    for complete details on our contactless payment demonstration projects and other ways in which our teams tackled mobility
-    service data, payment acceptance, and eligibility for discounts and benefits.
-  </p>
+    <p>
+      Throughout 2021, Cal-ITP forged new partnerships and live-tested solutions, advancing our vision across our three primary
+      project areas. Check out our
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="purple-link"
+        href="{{ site.baseurl }}/assets/Cal-ITP.2021.Accomplishments.Report.pdf"
+        >2021 Accomplishments Report</a
+      >
+      for complete details on our contactless payment demonstration projects and other ways in which our teams tackled mobility
+      service data, payment acceptance, and eligibility for discounts and benefits.
+    </p>
 
-  <p>
-    In March 2022, Cal-ITP announced its
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="red-link"
-      href="{{ site.baseurl }}/assets/Cal-ITP.Market.Consultation.Benefits.Administrator.pdf"
-      >Market Consultation: Benefits Administrator</a
-    >, inviting companies to contribute answers to a set of five questions that could shape the way that California residents
-    qualify for and receive benefits, starting with transit discounts.
-  </p>
+    <p>
+      In March 2022, Cal-ITP announced its
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="red-link"
+        href="{{ site.baseurl }}/assets/Cal-ITP.Market.Consultation.Benefits.Administrator.pdf"
+        >Market Consultation: Benefits Administrator</a
+      >, inviting companies to contribute answers to a set of five questions that could shape the way that California residents
+      qualify for and receive benefits, starting with transit discounts.
+    </p>
 
-  <p>
-    In June 2022, Cal-ITP announced a
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="gold-link"
-      href="{{ site.baseurl }}/assets/Cal-ITP.Open.Data.Standard.Improve.Transit.Agency.Operations.pdf"
-      >new open data standard</a
-    >
-    to improve transit agency operations and promote an interoperable transit ecosystem by improving the flow of data and
-    information sharing. The Operational Data Standard (ODS) leverages the existing GTFS standard used by transit agencies and
-    riders all over the world for transit service information and extends it to include data about personnel, scheduled
-    maintenance, and non-revenue service. The ODS specification is a product of the Operational Data Standard Working Group, a
-    coalition of more than 40 transit agencies, transit technology vendors such as computer-aided dispatch/automatic vehicle
-    location (CAD/AVL) companies, transit scheduling companies, and other contributors.
-  </p>
+    <p>
+      In June 2022, Cal-ITP announced a
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="gold-link"
+        href="{{ site.baseurl }}/assets/Cal-ITP.Open.Data.Standard.Improve.Transit.Agency.Operations.pdf"
+        >new open data standard</a
+      >
+      to improve transit agency operations and promote an interoperable transit ecosystem by improving the flow of data and
+      information sharing. The Operational Data Standard (ODS) leverages the existing GTFS standard used by transit agencies and
+      riders all over the world for transit service information and extends it to include data about personnel, scheduled
+      maintenance, and non-revenue service. The ODS specification is a product of the Operational Data Standard Working Group, a
+      coalition of more than 40 transit agencies, transit technology vendors such as computer-aided dispatch/automatic vehicle
+      location (CAD/AVL) companies, transit scheduling companies, and other contributors.
+    </p>
+  </div>
 </section>
 
 <picture class="railway">
@@ -272,34 +278,36 @@ layout: default
   />
 </picture>
 
-<section id="funfacts" class="constricted">
-  <h2>Helping California achieve critical goals through transportation</h2>
-  <p class="important">
-    Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success stories
-    from transit providers around the world.
-  </p>
+<section id="funfacts" class="row justify-content-center">
+  <div class="col-lg-6 col-md-8 col-12">
+    <h2>Helping California achieve critical goals through transportation</h2>
+    <p class="important">
+      Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success
+      stories from transit providers around the world.
+    </p>
 
-  <section id="facts">
-    <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
-    <section>
-      <h3>Improve the customer experience</h3>
-    </section>
+    <section id="facts">
+      <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
+      <section>
+        <h3>Improve the customer experience</h3>
+      </section>
 
-    <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
-    <section>
-      <h3>Increase transit ridership</h3>
-    </section>
+      <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
+      <section>
+        <h3>Increase transit ridership</h3>
+      </section>
 
-    <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
-    <section>
-      <h3>Lower costs for transit providers and riders</h3>
-    </section>
+      <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
+      <section>
+        <h3>Lower costs for transit providers and riders</h3>
+      </section>
 
-    <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
-    <section>
-      <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
+      <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
+      <section>
+        <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
+      </section>
     </section>
-  </section>
+  </div>
 </section>
 
 <picture class="railway">
@@ -310,8 +318,8 @@ layout: default
   />
 </picture>
 
-<section id="reachout" class="constricted">
-  <div class="col-6">
+<section id="reachout" class="row justify-content-center">
+  <div class="col-lg-6 col-md-8 col-12">
     <h2>The time is now—reach out to help and to learn more</h2>
     <p>This initiative is critical now more than ever.</p>
     <p>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -206,12 +206,6 @@ p.important {
   text-decoration-style: dotted;
 }
 
-.constricted {
-  width: 50vw;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 #funfacts #facts {
   display: grid;
   grid-template-columns: 1fr 8fr;
@@ -313,9 +307,6 @@ p.important {
 }
 
 @media (max-width: 1024px) {
-  .constricted {
-    width: 80vw;
-  }
   #deck {
     grid-template-rows: min-content 1fr;
     grid-template-columns: 1fr;
@@ -433,11 +424,6 @@ p.important {
   #lastminute .box {
     width: 100%;
     border-radius: 15px;
-  }
-  .constricted {
-    width: 90vw;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   #funfacts #facts {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1,8 +1,3 @@
-article {
-  margin-left: auto;
-  margin-right: auto;
-  width: 80vw;
-}
 h1,
 h2,
 h3,
@@ -406,11 +401,6 @@ p.important {
   }
 }
 @media (max-width: 540px) {
-  article {
-    margin-left: initial;
-    margin-right: initial;
-    width: 100vw;
-  }
   header nav .links.visible {
     grid-template-rows: repeat(3, min-content);
     grid-template-columns: 1fr;
@@ -478,8 +468,5 @@ p.important {
   header {
     position: fixed;
     top: 0;
-  }
-  article {
-    margin-top: 140px;
   }
 }


### PR DESCRIPTION
closes #123 

## What this PR does

### Removes Article
- Removes use of `<article>`. 
- Deletes `article` CSS.
- Uses `<main class="container">` in `default.html` layout instead. All pages should now use `<section class="row">` and `<div class="col-6">` syntax logic.

### Removes Constricted
- Removes use of `class="constricted"` and replaces it with `row/col/justify-center`
- Deletes `.constricted` CSS.

## What this PR does NOT do
- Refactor out CSS Grid from Footer, Header (to come in #122), and any other homepage content sections (beyond the "constricted" style)

## Screenshots

### Removes Article refactor
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/db260ef8-699f-4add-b63a-013d64148e4c">
Note: This header top issue will be fixed in #122 

### Removes Constricted refactor
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/e3745e2e-e822-4046-aa9b-8074c72bee8a">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/0779fee6-8791-497a-be3f-b202e2757047">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/135276e3-4ded-4a70-9957-7f942767a131"
