### PR TITLE
Refactor: Remove article, constricted and use Bootstrap instead 

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -5,6 +5,8 @@
   </head>
 
   <body>
-    {% include header.html %} {{content}} {% include footer.html %}
+    {% include header.html %}
+    <main class="container">{{content}}</main>
+    {% include footer.html %}
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -3,266 +3,259 @@ title: "Example"
 layout: default
 ---
 
-<article>
-  <section id="deck">
-    <section>
-      <h1>A modern and consistent transportation experience throughout California</h1>
-      <p>
-        Learn how the California Integrated Travel Project (Cal-ITP) is making riding by bus and train simpler and more
-        cost-effective—for providers and customers.
-      </p>
-    </section>
-
-    <picture>
-      <img
-        id="triforce"
-        src="images/hero-header.png"
-        alt="A trio of images, clockwise from top: a bus, a train platform with a sign that announces “Next train in 3 minutes,” and a transit rider paying their fare by tapping their smartphone’s mobile wallet on a payment reader when boarding"
-      />
-    </picture>
+<section id="deck">
+  <section>
+    <h1>A modern and consistent transportation experience throughout California</h1>
+    <p>
+      Learn how the California Integrated Travel Project (Cal-ITP) is making riding by bus and train simpler and more
+      cost-effective—for providers and customers.
+    </p>
   </section>
 
-  <picture class="railway d-none d-md-block">
+  <picture>
     <img
-      id="tracks-0"
-      src="images/tracks-divider-0.png"
-      alt="Decorative element with dots and dashes, meant to resemble a transit map"
+      id="triforce"
+      src="images/hero-header.png"
+      alt="A trio of images, clockwise from top: a bus, a train platform with a sign that announces “Next train in 3 minutes,” and a transit rider paying their fare by tapping their smartphone’s mobile wallet on a payment reader when boarding"
     />
   </picture>
-  <picture class="railway d-md-none">
-    <img
-      id="tracks-0-sm"
-      src="images/tracks-divider-0-sm.png"
-      alt="Decorative element with dots and dashes, meant to resemble a transit map"
-    />
-  </picture>
+</section>
 
-  <section id="details">
-    <section id="enabling-contactless-payment" class="box">
-      <section class="callout">
-        <picture>
-          <img
-            src="images/enabling-contactless-payment.png"
-            alt="A trio of images, from left to right: a contactless-enabled bank card, a mobile wallet on a smartphone, and a mobile wallet on a smartwatch"
-            width="142"
-          />
-        </picture>
-        <section class="right-callout">
-          <h3>Enabling contactless payments</h3>
-          <p>
-            Adding a contactless payment reader to a bus or train means customers can quickly and easily tap to pay as they board
-            with the bank card or smartphone that’s already in their pocket—just like they’d tap to buy a coffee.
-          </p>
-          <p>
-            Starting with
-            <a
-              href="https://mst.org/news_items/monterey-salinas-transit-announces-launch-of-contactless-fare-payment-demonstration/"
-              rel="noreferrer"
-              target="_blank"
-              >Monterey-Salinas Transit</a
-            >, Cal-ITP and partners like Visa are demonstrating how a transit provider that has traditionally used cash and
-            agency-specific fare cards can accept contactless bank card payments like any other merchant.
-          </p>
-          <p>
-            And to make it easier and more affordable for public transportation providers anywhere in the U.S. to acquire the
-            building blocks of contactless payments, the California Department of General Services (DGS)—in collaboration with
-            Cal-ITP—conducted a Request for Proposal that established Master Service Agreements (MSAs) allowing public
-            transportation providers to purchase contactless payments hardware and software directly from vendors without further
-            competitive bidding. Learn about the MSAs in our
-            <a href="{{ site.baseurl }}/assets/Contactless.Payments.MSA.pdf" target="_blank">press release</a>, and
-            <a href="https://www.camobilitymarketplace.org/contracts" target="_blank">view the MSAs</a>.
-          </p>
-        </section>
-      </section>
-    </section>
+<picture class="railway d-none d-md-block">
+  <img
+    id="tracks-0"
+    src="images/tracks-divider-0.png"
+    alt="Decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
+<picture class="railway d-md-none">
+  <img
+    id="tracks-0-sm"
+    src="images/tracks-divider-0-sm.png"
+    alt="Decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
 
-    <section id="automating-customer-discounts" class="box">
-      <section class="callout">
-        <picture>
-          <img src="images/automating-customer-discounts.png" alt="Checking a state-issued identification" width="131" />
-        </picture>
-        <section class="right-callout">
-          <h3>Automating customer discounts</h3>
-          <p>
-            Our <a rel="noreferrer" target="_blank" href="https://benefits.calitp.org">Cal-ITP Benefits</a> web application
-            streamlines the process for transit riders to instantly qualify for and receive discounts, starting with
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href="https://mst.org/news_items/monterey-salinas-transit-mst-announces-discount-contactless-fares-for-both-local-and-visiting-riders-65-with-launch-of-new-benefits-eligibility-verification-website/"
-              >Monterey-Salinas Transit</a
-            >
-            (MST), which offers a half-price Senior Fare. Now older adults (65+) who are able to
-            <a
-              href="https://login.gov/help/verify-your-identity/how-to-verify-your-identity/#requirements-for-identity-verification"
-              target="_blank"
-              >electronically verify their identity</a
-            >
-            are able to access MST's reduced fares without the hassle of paperwork.
-          </p>
-          <p>
-            We worked with state partners on this product launch, and next we're working to bring youth, lower-income riders,
-            veterans, people with disabilities, and others the same instant access to free or reduced fares across all California
-            transit providers, without having to prove eligibility to each agency.
-          </p>
-        </section>
-      </section>
-    </section>
-
-    <section id="standardizing-trip-quality" class="box">
-      <section class="callout">
-        <picture>
-          <img
-            src="images/standardizing-trip-quality.png"
-            alt="A bus that transits real-time arrival and departure information"
-            width="106"
-          />
-        </picture>
-        <section class="right-callout">
-          <h3>Standardizing information for easy trip planning</h3>
-          <p>
-            Cal-ITP is helping transit providers remove the guesswork for riders wondering when the next bus or train will arrive
-            or if they’ll make their connection by using the General Transit Feed Specification (GTFS)—the global standard for
-            publishing transit information. Cal-ITP developed
-            <a
-              rel="noreferrer"
-              target="_blank"
-              href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
-              >California Minimum GTFS Guidelines</a
-            >
-            and is working to ensure statewide GTFS static coverage by the end of 2020 and GTFS Realtime by the end of 2021. Along
-            the way, the Cal-ITP team will support transit providers by assessing their systems and providing technical assistance
-            so riders can easily access complete, accurate, consistent, and timely mobility data for their journey.
-          </p>
-        </section>
-      </section>
-    </section>
-  </section>
-
-  <section id="about" class="constricted">
-    <h2>Bringing industry standards to California’s transit providers</h2>
-    <p>
-      There are hundreds of public transit providers in California—with no consistent way to collect fares, verify eligibility for
-      fare discounts, or provide real-time vehicle information to customers on their phones.
-    </p>
-    <p>
-      The lack of a consistent experience creates barriers for new customers, complicates travel across different systems, and
-      increases expenses for individual providers.
-    </p>
-    <p>
-      Supported by the
-      <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/"
-        >California State Transportation Agency</a
-      >
-      (CalSTA) and the
-      <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ "
-        >California Department of Transportation</a
-      >
-      (Caltrans) through a grant from the
-      <a
-        rel="noreferrer"
-        target="_blank"
-        class="blue-link"
-        href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
-        >California Transit and Intercity Rail Capital Program</a
-      >
-      (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
-      cost-effective for everyone.
-    </p>
-  </section>
-
-  <picture class="railway">
-    <img
-      id="tracks-1"
-      src="images/tracks-divider-1.png"
-      alt="Decorative element with dots and dashes, meant to resemble a transit map"
-    />
-  </picture>
-
-  <section id="funfacts" class="constricted">
-    <h2>Helping California achieve critical goals through transportation</h2>
-    <p class="important">
-      Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success
-      stories from transit providers around the world.
-    </p>
-
-    <section id="facts">
-      <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
-      <section>
-        <h3>Improve the customer experience</h3>
-      </section>
-
-      <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
-      <section>
-        <h3>Increase transit ridership</h3>
-      </section>
-
-      <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
-      <section>
-        <h3>Lower costs for transit providers and riders</h3>
-      </section>
-
-      <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
-      <section>
-        <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
-      </section>
-    </section>
-  </section>
-
-  <picture class="railway">
-    <img
-      id="tracks-2"
-      src="images/tracks-divider-2.png"
-      alt="Another decorative element with dots and dashes, meant to resemble a transit map"
-    />
-  </picture>
-
-  <section id="reachout" class="constricted">
-    <h2>The time is now—reach out to help and to learn more</h2>
-    <p>This initiative is critical now more than ever.</p>
-    <p>
-      Cal-ITP is working with transportation agencies across the country to launch a program that can immediately improve the
-      ridership experience. Contact us to learn more.
-    </p>
-  </section>
-
-  <section id="lastminute">
-    <section id="connect" class="box">
-      <section class="blob">
-        <picture
-          ><img
-            src="images/connect.png"
-            alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
-            width="80"
-        /></picture>
-        <h3>Connect with Cal-ITP</h3>
-        <p>Drop us a line at <a rel="noreferrer" target="_blank" href="mailto:hello@calitp.org">hello@calitp.org</a> to</p>
-        <ul>
-          <li>request technical assistance</li>
-          <li>get more information</li>
-          <li>offer collaborative support</li>
-          <li>join our email list for updates</li>
-        </ul>
-      </section>
-    </section>
-
-    <section id="update" class="box">
-      <section class="blob">
-        <picture
-          ><img
-            src="images/stay-up-to-date.png"
-            alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
-            width="80"
-        /></picture>
-        <h3>Stay up to date</h3>
+<section id="details">
+  <section id="enabling-contactless-payment" class="box">
+    <section class="callout">
+      <picture>
+        <img
+          src="images/enabling-contactless-payment.png"
+          alt="A trio of images, from left to right: a contactless-enabled bank card, a mobile wallet on a smartphone, and a mobile wallet on a smartwatch"
+          width="142"
+        />
+      </picture>
+      <section class="right-callout">
+        <h3>Enabling contactless payments</h3>
         <p>
-          See our <a href="https://dot.ca.gov/cal-itp" rel="noreferrer" target="_blank">latest milestones</a>, and subscribe to
-          the
-          <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website" rel="noreferrer" target="_blank"
-            >Caltrans Mobility Newsletter</a
-          >, a free biweekly resource with frequent Cal-ITP project updates.
+          Adding a contactless payment reader to a bus or train means customers can quickly and easily tap to pay as they board
+          with the bank card or smartphone that’s already in their pocket—just like they’d tap to buy a coffee.
+        </p>
+        <p>
+          Starting with
+          <a
+            href="https://mst.org/news_items/monterey-salinas-transit-announces-launch-of-contactless-fare-payment-demonstration/"
+            rel="noreferrer"
+            target="_blank"
+            >Monterey-Salinas Transit</a
+          >, Cal-ITP and partners like Visa are demonstrating how a transit provider that has traditionally used cash and
+          agency-specific fare cards can accept contactless bank card payments like any other merchant.
+        </p>
+        <p>
+          And to make it easier and more affordable for public transportation providers anywhere in the U.S. to acquire the
+          building blocks of contactless payments, the California Department of General Services (DGS)—in collaboration with
+          Cal-ITP—conducted a Request for Proposal that established Master Service Agreements (MSAs) allowing public
+          transportation providers to purchase contactless payments hardware and software directly from vendors without further
+          competitive bidding. Learn about the MSAs in our
+          <a href="{{ site.baseurl }}/assets/Contactless.Payments.MSA.pdf" target="_blank">press release</a>, and
+          <a href="https://www.camobilitymarketplace.org/contracts" target="_blank">view the MSAs</a>.
         </p>
       </section>
     </section>
   </section>
-</article>
+
+  <section id="automating-customer-discounts" class="box">
+    <section class="callout">
+      <picture>
+        <img src="images/automating-customer-discounts.png" alt="Checking a state-issued identification" width="131" />
+      </picture>
+      <section class="right-callout">
+        <h3>Automating customer discounts</h3>
+        <p>
+          Our <a rel="noreferrer" target="_blank" href="https://benefits.calitp.org">Cal-ITP Benefits</a> web application
+          streamlines the process for transit riders to instantly qualify for and receive discounts, starting with
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://mst.org/news_items/monterey-salinas-transit-mst-announces-discount-contactless-fares-for-both-local-and-visiting-riders-65-with-launch-of-new-benefits-eligibility-verification-website/"
+            >Monterey-Salinas Transit</a
+          >
+          (MST), which offers a half-price Senior Fare. Now older adults (65+) who are able to
+          <a
+            href="https://login.gov/help/verify-your-identity/how-to-verify-your-identity/#requirements-for-identity-verification"
+            target="_blank"
+            >electronically verify their identity</a
+          >
+          are able to access MST's reduced fares without the hassle of paperwork.
+        </p>
+        <p>
+          We worked with state partners on this product launch, and next we're working to bring youth, lower-income riders,
+          veterans, people with disabilities, and others the same instant access to free or reduced fares across all California
+          transit providers, without having to prove eligibility to each agency.
+        </p>
+      </section>
+    </section>
+  </section>
+
+  <section id="standardizing-trip-quality" class="box">
+    <section class="callout">
+      <picture>
+        <img
+          src="images/standardizing-trip-quality.png"
+          alt="A bus that transits real-time arrival and departure information"
+          width="106"
+        />
+      </picture>
+      <section class="right-callout">
+        <h3>Standardizing information for easy trip planning</h3>
+        <p>
+          Cal-ITP is helping transit providers remove the guesswork for riders wondering when the next bus or train will arrive or
+          if they’ll make their connection by using the General Transit Feed Specification (GTFS)—the global standard for
+          publishing transit information. Cal-ITP developed
+          <a
+            rel="noreferrer"
+            target="_blank"
+            href="https://dot.ca.gov/cal-itp/california-minimum-general-transit-feed-specification-gtfs-guidelines"
+            >California Minimum GTFS Guidelines</a
+          >
+          and is working to ensure statewide GTFS static coverage by the end of 2020 and GTFS Realtime by the end of 2021. Along
+          the way, the Cal-ITP team will support transit providers by assessing their systems and providing technical assistance
+          so riders can easily access complete, accurate, consistent, and timely mobility data for their journey.
+        </p>
+      </section>
+    </section>
+  </section>
+</section>
+
+<section id="about" class="constricted">
+  <h2>Bringing industry standards to California’s transit providers</h2>
+  <p>
+    There are hundreds of public transit providers in California—with no consistent way to collect fares, verify eligibility for
+    fare discounts, or provide real-time vehicle information to customers on their phones.
+  </p>
+  <p>
+    The lack of a consistent experience creates barriers for new customers, complicates travel across different systems, and
+    increases expenses for individual providers.
+  </p>
+  <p>
+    Supported by the
+    <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/">California State Transportation Agency</a>
+    (CalSTA) and the
+    <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ ">California Department of Transportation</a>
+    (Caltrans) through a grant from the
+    <a
+      rel="noreferrer"
+      target="_blank"
+      class="blue-link"
+      href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
+      >California Transit and Intercity Rail Capital Program</a
+    >
+    (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
+    cost-effective for everyone.
+  </p>
+</section>
+
+<picture class="railway">
+  <img
+    id="tracks-1"
+    src="images/tracks-divider-1.png"
+    alt="Decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
+
+<section id="funfacts" class="constricted">
+  <h2>Helping California achieve critical goals through transportation</h2>
+  <p class="important">
+    Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success stories
+    from transit providers around the world.
+  </p>
+
+  <section id="facts">
+    <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
+    <section>
+      <h3>Improve the customer experience</h3>
+    </section>
+
+    <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
+    <section>
+      <h3>Increase transit ridership</h3>
+    </section>
+
+    <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
+    <section>
+      <h3>Lower costs for transit providers and riders</h3>
+    </section>
+
+    <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
+    <section>
+      <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
+    </section>
+  </section>
+</section>
+
+<picture class="railway">
+  <img
+    id="tracks-2"
+    src="images/tracks-divider-2.png"
+    alt="Another decorative element with dots and dashes, meant to resemble a transit map"
+  />
+</picture>
+
+<section id="reachout" class="constricted">
+  <h2>The time is now—reach out to help and to learn more</h2>
+  <p>This initiative is critical now more than ever.</p>
+  <p>
+    Cal-ITP is working with transportation agencies across the country to launch a program that can immediately improve the
+    ridership experience. Contact us to learn more.
+  </p>
+</section>
+
+<section id="lastminute">
+  <section id="connect" class="box">
+    <section class="blob">
+      <picture
+        ><img
+          src="images/connect.png"
+          alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
+          width="80"
+      /></picture>
+      <h3>Connect with Cal-ITP</h3>
+      <p>Drop us a line at <a rel="noreferrer" target="_blank" href="mailto:hello@calitp.org">hello@calitp.org</a> to</p>
+      <ul>
+        <li>request technical assistance</li>
+        <li>get more information</li>
+        <li>offer collaborative support</li>
+        <li>join our email list for updates</li>
+      </ul>
+    </section>
+  </section>
+
+  <section id="update" class="box">
+    <section class="blob">
+      <picture
+        ><img
+          src="images/stay-up-to-date.png"
+          alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
+          width="80"
+      /></picture>
+      <h3>Stay up to date</h3>
+      <p>
+        See our <a href="https://dot.ca.gov/cal-itp" rel="noreferrer" target="_blank">latest milestones</a>, and subscribe to the
+        <a href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website" rel="noreferrer" target="_blank"
+          >Caltrans Mobility Newsletter</a
+        >, a free biweekly resource with frequent Cal-ITP project updates.
+      </p>
+    </section>
+  </section>
+</section>

--- a/src/index.html
+++ b/src/index.html
@@ -220,29 +220,6 @@ layout: default
   <section id="reachout" class="constricted">
     <h2>The time is now—reach out to help and to learn more</h2>
     <p>This initiative is critical now more than ever.</p>
-    <p>
-      As COVID-19 hit the United States, many transit providers saw ridership decrease. But many who depend on transit do not have
-      the privilege to work from home—including many essential workers. Reliable transit access and contactless payments are
-      critical components to ensuring that transit forms a key part of the COVID-19 crisis response and recovery.
-    </p>
-    <p>
-      Cal-ITP also supports the state’s longer-term equity, economic development, and climate goals as delineated in
-      <a
-        rel="noreferrer"
-        target="_blank"
-        class="red-link"
-        href="https://www.gov.ca.gov/wp-content/uploads/2020/09/9.23.20-EO-N-79-20-Climate.pdf"
-        >2020 California Executive Order N-79-20</a
-      >. Increased transit ridership is a key component of California’s strategy to reduce greenhouse gas emissions and combat
-      climate change. To reach its full potential, Cal-ITP will provide individual transit providers with the buying power to save
-      on the equipment needed to ensure that transit remains a core tenet of the state’s mobility.
-    </p>
-    <p>
-      As California faces these unprecedented challenges, there is a sense of urgency around creating a seamless, simpler, and
-      more sustainable transit experience in California. Collaboration and collective problem-solving are needed at all levels of
-      government, public and private transit providers, academia, and think tanks, as well as vendors of relevant technologies and
-      business models. Join us.
-    </p>
   </section>
 
   <section id="lastminute">

--- a/src/index.html
+++ b/src/index.html
@@ -138,32 +138,38 @@ layout: default
   </section>
 </section>
 
-<section id="about" class="constricted">
-  <h2>Bringing industry standards to California’s transit providers</h2>
-  <p>
-    There are hundreds of public transit providers in California—with no consistent way to collect fares, verify eligibility for
-    fare discounts, or provide real-time vehicle information to customers on their phones.
-  </p>
-  <p>
-    The lack of a consistent experience creates barriers for new customers, complicates travel across different systems, and
-    increases expenses for individual providers.
-  </p>
-  <p>
-    Supported by the
-    <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/">California State Transportation Agency</a>
-    (CalSTA) and the
-    <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ ">California Department of Transportation</a>
-    (Caltrans) through a grant from the
-    <a
-      rel="noreferrer"
-      target="_blank"
-      class="blue-link"
-      href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
-      >California Transit and Intercity Rail Capital Program</a
-    >
-    (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
-    cost-effective for everyone.
-  </p>
+<section id="about" class="row justify-content-center">
+  <div class="col-12 col-md-8 col-lg-6">
+    <h2>Bringing industry standards to California’s transit providers</h2>
+    <p>
+      There are hundreds of public transit providers in California—with no consistent way to collect fares, verify eligibility for
+      fare discounts, or provide real-time vehicle information to customers on their phones.
+    </p>
+    <p>
+      The lack of a consistent experience creates barriers for new customers, complicates travel across different systems, and
+      increases expenses for individual providers.
+    </p>
+    <p>
+      Supported by the
+      <a rel="noreferrer" target="_blank" class="red-link" href="https://calsta.ca.gov/"
+        >California State Transportation Agency</a
+      >
+      (CalSTA) and the
+      <a rel="noreferrer" target="_blank" class="green-link" href="https://dot.ca.gov/ "
+        >California Department of Transportation</a
+      >
+      (Caltrans) through a grant from the
+      <a
+        rel="noreferrer"
+        target="_blank"
+        class="blue-link"
+        href="https://calsta.ca.gov/subject-areas/transit-intercity-rail-capital-prog"
+        >California Transit and Intercity Rail Capital Program</a
+      >
+      (<abbr>TIRCP</abbr>), the California Integrated Travel Project (Cal-ITP) is a statewide solution to make travel simpler and
+      cost-effective for everyone.
+    </p>
+  </div>
 </section>
 
 <picture class="railway">
@@ -174,34 +180,36 @@ layout: default
   />
 </picture>
 
-<section id="funfacts" class="constricted">
-  <h2>Helping California achieve critical goals through transportation</h2>
-  <p class="important">
-    Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success stories
-    from transit providers around the world.
-  </p>
+<section id="funfacts" class="row justify-content-center">
+  <div class="col-12 col-md-8 col-lg-6">
+    <h2>Helping California achieve critical goals through transportation</h2>
+    <p class="important">
+      Cal-ITP initiatives are grounded in real-world results. Here’s a sampling of what we plan to do, supported by success
+      stories from transit providers around the world.
+    </p>
 
-  <section id="facts">
-    <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
-    <section>
-      <h3>Improve the customer experience</h3>
-    </section>
+    <section id="facts">
+      <picture><img id="goal-1" src="images/number-1.png" alt="Number 1" /></picture>
+      <section>
+        <h3>Improve the customer experience</h3>
+      </section>
 
-    <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
-    <section>
-      <h3>Increase transit ridership</h3>
-    </section>
+      <picture><img id="goal-2" src="images/number-2.png" alt="Number 2" /></picture>
+      <section>
+        <h3>Increase transit ridership</h3>
+      </section>
 
-    <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
-    <section>
-      <h3>Lower costs for transit providers and riders</h3>
-    </section>
+      <picture><img id="goal-3" src="images/number-3.png" alt="Number 3" /></picture>
+      <section>
+        <h3>Lower costs for transit providers and riders</h3>
+      </section>
 
-    <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
-    <section>
-      <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
+      <picture><img id="goal-4" src="images/number-4.png" alt="Number 4" /></picture>
+      <section>
+        <h3>Reduce greenhouse gas emissions to reach environmental targets</h3>
+      </section>
     </section>
-  </section>
+  </div>
 </section>
 
 <picture class="railway">
@@ -212,13 +220,15 @@ layout: default
   />
 </picture>
 
-<section id="reachout" class="constricted">
-  <h2>The time is now—reach out to help and to learn more</h2>
-  <p>This initiative is critical now more than ever.</p>
-  <p>
-    Cal-ITP is working with transportation agencies across the country to launch a program that can immediately improve the
-    ridership experience. Contact us to learn more.
-  </p>
+<section id="reachout" class="row justify-content-center">
+  <div class="col-12 col-md-8 col-lg-6">
+    <h2>The time is now—reach out to help and to learn more</h2>
+    <p>This initiative is critical now more than ever.</p>
+    <p>
+      Cal-ITP is working with transportation agencies across the country to launch a program that can immediately improve the
+      ridership experience. Contact us to learn more.
+    </p>
+  </div>
 </section>
 
 <section id="lastminute">

--- a/src/index.html
+++ b/src/index.html
@@ -220,6 +220,10 @@ layout: default
   <section id="reachout" class="constricted">
     <h2>The time is now—reach out to help and to learn more</h2>
     <p>This initiative is critical now more than ever.</p>
+    <p>
+      Cal-ITP is working with transportation agencies across the country to launch a program that can immediately improve the
+      ridership experience. Contact us to learn more.
+    </p>
   </section>
 
   <section id="lastminute">

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -1,8 +1,3 @@
-article {
-  margin-left: auto;
-  margin-right: auto;
-  width: 76vw;
-}
 h1,
 h2,
 h3,
@@ -105,7 +100,7 @@ p.important {
 #deck {
   display: grid;
   grid-template-rows: 1fr;
-  grid-template-columns: .85fr 1fr;
+  grid-template-columns: 0.85fr 1fr;
   grid-gap: 3em;
   line-height: 1.1;
   align-items: center;
@@ -401,11 +396,6 @@ p.important {
   }
 }
 @media (max-width: 540px) {
-  article {
-    margin-left: initial;
-    margin-right: initial;
-    width: 100vw;
-  }
   header nav .links.visible {
     grid-template-rows: repeat(3, min-content);
     grid-template-columns: 1fr;
@@ -473,8 +463,5 @@ p.important {
   header {
     position: fixed;
     top: 0;
-  }
-  article {
-    margin-top: 140px;
   }
 }

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -201,12 +201,6 @@ p.important {
   text-decoration-style: dotted;
 }
 
-.constricted {
-  width: 50vw;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 #funfacts #facts {
   display: grid;
   grid-template-columns: 1fr 8fr;
@@ -308,9 +302,6 @@ p.important {
 }
 
 @media (max-width: 1024px) {
-  .constricted {
-    width: 80vw;
-  }
   #deck {
     grid-template-rows: min-content 1fr;
     grid-template-columns: 1fr;
@@ -428,11 +419,6 @@ p.important {
   #lastminute .box {
     width: 100%;
     border-radius: 15px;
-  }
-  .constricted {
-    width: 90vw;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   #funfacts #facts {


### PR DESCRIPTION
closes #123 

## What this PR does

### Removes Article
- Removes use of `<article>`. 
- Deletes `article` CSS.
- Uses `<main class="container">` in `default.html` layout instead. All pages should now use `<section class="row">` and `<div class="col-6">` syntax logic.

### Removes Constricted
- Removes use of `class="constricted"` and replaces it with `row/col/justify-center`
- Deletes `.constricted` CSS.

## What this PR does NOT do
- Refactor out CSS Grid from Footer, Header (to come in #122), and any other homepage content sections (beyond the "constricted" style)

## Screenshots

### Removes Article refactor
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/db260ef8-699f-4add-b63a-013d64148e4c">
Note: This header top issue will be fixed in #122 

### Removes Constricted refactor
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/e3745e2e-e822-4046-aa9b-8074c72bee8a">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/0779fee6-8791-497a-be3f-b202e2757047">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/135276e3-4ded-4a70-9957-7f942767a131"
