### PR TITLE
Chore: minor devcontainer cleanups

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,20 +4,24 @@
   "service": "site",
   "workspaceFolder": "/usr/src/calitp",
   "postAttachCommand": ["/bin/bash", ".devcontainer/postAttach.sh"],
-  "settings": {
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "terminal.integrated.profiles.linux": {
-      "bash": {
-        "path": "/bin/bash"
-      }
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/bin/bash"
+          }
+        }
+      },
+      "extensions": [
+        "bungcip.better-toml",
+        "eamodio.gitlens",
+        "esbenp.prettier-vscode",
+        "mhutchie.git-graph",
+        "redhat.vscode-xml",
+        "sissel.shopify-liquid"
+      ]
     }
-  },
-  "extensions": [
-    "bungcip.better-toml",
-    "eamodio.gitlens",
-    "esbenp.prettier-vscode",
-    "mhutchie.git-graph",
-    "redhat.vscode-xml",
-    "sissel.shopify-liquid"
-  ]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,13 +6,8 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "[javascript]": {
-    "editor.tabSize": 2
-  },
-  "[json]": {
-    "editor.tabSize": 2
-  },
-  "[markdown]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.tabSize": 2,
+  "files.associations": {
+    "*.html": "liquid"
   }
 }


### PR DESCRIPTION
* Default to tabsize 2 for all files
* Associate `*.html` with the Liquid plugin for better formatting/syntax highlighting
* Clean up devcontainer config syntax