### PR TITLE
fix(default): use Bootstrap@5.2.3

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -10,8 +10,8 @@
     {% include footer.html %}
 
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4"
       crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
Bootstrap JS and CSS should both be at Bootstrap@5.2.3.