### PR TITLE
Filtering spike

### DIFF
--- a/src/_includes/press_listing.html
+++ b/src/_includes/press_listing.html
@@ -1,0 +1,17 @@
+  {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
+  {% assign all_press = site.press | reverse %}
+  {% for press in all_press %}
+    {% assign url = press.url %}
+    {% if press.external %}
+      {% assign url = press.external %}
+    {% endif %}
+    {% if include.tag == empty or include.tag and press.tags contains include.tag %}
+    <article class="press-item"></article>
+      <a href="{{ url }}" {% if press.external %}target="_blank"{% endif %}>{{ press.title }}</a>
+      <br/>
+      <span class="tags">{{ press.tags | join: ", " }}</span>
+      |
+      {% include date.html date=press.date format = "%b %Y" %}
+    </article>
+    {% endif %}
+  {% endfor %}

--- a/src/press.html
+++ b/src/press.html
@@ -90,6 +90,8 @@ layout: default
 <script>
   const pills = document.querySelectorAll("button[data-bs-toggle='pill']");
   pills.forEach(p => {
+// Bootstrap does not handle un-selecting a tab, so the following listeners are needed:
+
 // mouse-click or Enter key will trigger "click" event and should toggle the pill's state
     p.addEventListener("click", event => toggleSelection(p.id));
 
@@ -102,10 +104,10 @@ layout: default
 
   function toggleSelection(id) {
     const pillToToggle = document.querySelector("#" + id);
-    if (! pillToToggle.classList.contains("selected")) {
+    if (! pillToToggle.classList.contains("cal-itp-selected")) {
       select(pillToToggle);
     } else {
-      pillToToggle.classList.remove("selected");
+      pillToToggle.classList.remove("cal-itp-selected");
       pillToToggle.classList.remove("active");
       hideTab(pillToToggle.id);
 
@@ -114,12 +116,12 @@ layout: default
   }
 
   function select(pill) {
-    pill.classList.add("selected");
+    pill.classList.add("cal-itp-selected");
 
     const pills = document.querySelectorAll("button[data-bs-toggle='pill']");
     let pillSet = new Set(pills);
     pillSet.delete(pill);
-    pillSet.forEach(pill => pill.classList.remove("selected"));
+    pillSet.forEach(pill => pill.classList.remove("cal-itp-selected"));
   }
 
   function hideTab(pillId) {

--- a/src/press.html
+++ b/src/press.html
@@ -11,37 +11,6 @@ layout: default
   </style>
 </noscript>
 
-<script>
-  function deselect(id) {
-    const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
-    const allTab = document.querySelector("#pills-all");
-
-    const selectedPill = document.querySelector("#" + id);
-    if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
-      selectedPill.classList.add("selected");
-
-// hide tab with all articles
-      allTab.classList.remove("show");
-      allTab.classList.remove("active");
-    } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
-      selectedPill.classList.remove("selected");
-      selectedPill.classList.remove("active");
-
-      const selectedTab = document.querySelector("div[aria-labelledby='" + id + "']")
-      selectedTab.classList.remove("show");
-      selectedTab.classList.remove("active");
-
-// show tab with all articles
-      allTab.classList.add("show");
-      allTab.classList.add("active");
-    }
-
-/* remove "selected" from all other pills */
-    let pillSet = new Set(pills);
-    pillSet.delete(selectedPill);
-    pillSet.forEach(pill => pill.classList.remove("selected"));
-  }
-</script>
 <h1>Press</h1>
 <ul
   class="nav nav-pills mb-3 gap-2 hide-if-noscript"
@@ -120,3 +89,35 @@ layout: default
     </div>
   </div>
 </section>
+
+<script>
+  function deselect(id) {
+    const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
+    const allTab = document.querySelector("#pills-all");
+
+    const selectedPill = document.querySelector("#" + id);
+    if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
+      selectedPill.classList.add("selected");
+
+// hide tab with all articles
+      allTab.classList.remove("show");
+      allTab.classList.remove("active");
+    } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
+      selectedPill.classList.remove("selected");
+      selectedPill.classList.remove("active");
+
+      const selectedTab = document.querySelector("div[aria-labelledby='" + id + "']")
+      selectedTab.classList.remove("show");
+      selectedTab.classList.remove("active");
+
+// show tab with all articles
+      allTab.classList.add("show");
+      allTab.classList.add("active");
+    }
+
+/* remove "selected" from all other pills */
+    let pillSet = new Set(pills);
+    pillSet.delete(selectedPill);
+    pillSet.forEach(pill => pill.classList.remove("selected"));
+  }
+</script>

--- a/src/press.html
+++ b/src/press.html
@@ -25,8 +25,7 @@ layout: default
       type="button"
       role="tab"
       aria-controls="pills-contactless"
-      aria-selected="false"
-      onclick="deselect('pills-contactless-tab')">Contactless Payments</button>
+      aria-selected="false">Contactless Payments</button>
   </li>
   <li class="nav-item" role="presentation">
     <button
@@ -37,8 +36,7 @@ layout: default
       type="button"
       role="tab"
       aria-controls="pills-benefits"
-      aria-selected="false"
-      onclick="deselect('pills-benefits-tab')">Benefits</button>
+      aria-selected="false">Benefits</button>
   </li>
   <li class="nav-item" role="presentation">
     <button
@@ -49,8 +47,7 @@ layout: default
       type="button"
       role="tab"
       aria-controls="pills-gtfs"
-      aria-selected="false"
-      onclick="deselect('pills-gtfs-tab')">GTFS</button>
+      aria-selected="false">GTFS</button>
   </li>
 </ul>
 
@@ -93,49 +90,59 @@ layout: default
 <script>
   const pills = document.querySelectorAll("button[data-bs-toggle='pill']");
   pills.forEach(p => {
-    p.addEventListener('shown.bs.tab', event => {
-      const allTab = document.querySelector("#pills-all");
-      allTab.classList.remove("show");
-      allTab.classList.remove("active");
-    });
-    p.addEventListener('keyup', event => {
-      if (event.keyCode == 37 || event.keyCode == 38 || event.keyCode == 39 || event.keyCode == 40) {
-        if (!p.classList.contains("selected")) {
-          p.classList.add("selected");
+// mouse-click or Enter key will trigger "click" event and should toggle the pill's state
+    p.addEventListener("click", event => toggleSelection(p.id));
 
-          let pillSet = new Set(pills);
-          pillSet.delete(p);
-          pillSet.forEach(pill => pill.classList.remove("selected"));
-        }
+// mouse-click, Enter key, or arrow keys will trigger "shown.bs.tab" event and should hide the "all" tab
+    p.addEventListener("shown.bs.tab", event => hideAllTab());
 
-      }
-    });
+// arrow keys will trigger "keyup" event and should set pill to "selected" (no way to deselect using arrow key)
+    p.addEventListener("keyup", event => selectByArrowKey(event, p));
   });
 
+  function toggleSelection(id) {
+    const pillToToggle = document.querySelector("#" + id);
+    if (! pillToToggle.classList.contains("selected")) {
+      select(pillToToggle);
+    } else {
+      pillToToggle.classList.remove("selected");
+      pillToToggle.classList.remove("active");
+      hideTab(pillToToggle.id);
 
-  function deselect(id) {
-    const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
+      showAllTab();
+    }
+  }
+
+  function select(pill) {
+    pill.classList.add("selected");
+
+    const pills = document.querySelectorAll("button[data-bs-toggle='pill']");
+    let pillSet = new Set(pills);
+    pillSet.delete(pill);
+    pillSet.forEach(pill => pill.classList.remove("selected"));
+  }
+
+  function hideTab(pillId) {
+    const selectedTab = document.querySelector("div[aria-labelledby='" + pillId + "']")
+    selectedTab.classList.remove("show");
+    selectedTab.classList.remove("active");
+  }
+
+  function showAllTab() {
     const allTab = document.querySelector("#pills-all");
+    allTab.classList.add("show");
+    allTab.classList.add("active");
+  }
 
-    const selectedPill = document.querySelector("#" + id);
-    if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
-      selectedPill.classList.add("selected");
+  function hideAllTab() {
+    const allTab = document.querySelector("#pills-all");
+    allTab.classList.remove("show");
+    allTab.classList.remove("active");
+  }
 
-/* remove "selected" from all other pills */
-      let pillSet = new Set(pills);
-      pillSet.delete(selectedPill);
-      pillSet.forEach(pill => pill.classList.remove("selected"));
-    } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
-      selectedPill.classList.remove("selected");
-      selectedPill.classList.remove("active");
-
-      const selectedTab = document.querySelector("div[aria-labelledby='" + id + "']")
-      selectedTab.classList.remove("show");
-      selectedTab.classList.remove("active");
-
-// show tab with all articles
-      allTab.classList.add("show");
-      allTab.classList.add("active");
+  function selectByArrowKey(event, pill) {
+    if (event.keyCode == 37 || event.keyCode == 38 || event.keyCode == 39 || event.keyCode == 40) {
+      select(pill);
     }
   }
 </script>

--- a/src/press.html
+++ b/src/press.html
@@ -91,6 +91,16 @@ layout: default
 </section>
 
 <script>
+  const pills = document.querySelectorAll("button[data-bs-toggle='pill']");
+  pills.forEach(p => {
+    p.addEventListener('shown.bs.tab', event => {
+      const allTab = document.querySelector("#pills-all");
+      allTab.classList.remove("show");
+      allTab.classList.remove("active");
+    });
+  });
+
+
   function deselect(id) {
     const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
     const allTab = document.querySelector("#pills-all");
@@ -98,10 +108,6 @@ layout: default
     const selectedPill = document.querySelector("#" + id);
     if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
       selectedPill.classList.add("selected");
-
-// hide tab with all articles
-      allTab.classList.remove("show");
-      allTab.classList.remove("active");
     } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
       selectedPill.classList.remove("selected");
       selectedPill.classList.remove("active");

--- a/src/press.html
+++ b/src/press.html
@@ -2,21 +2,28 @@
 layout: default
 ---
 
+{% comment %} needs to go in head element {% endcomment %}
+<noscript>
+  <style>
+    .hide-if-noscript {
+      display: none;
+    }
+  </style>
+</noscript>
+
 <script>
   function deselect(id) {
     const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
     const allTab = document.querySelector("#pills-all");
 
     const selectedPill = document.querySelector("#" + id);
-    if (!selectedPill.classList.contains("selected")) {
-      /* mark it as selected */
+    if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
       selectedPill.classList.add("selected");
 
-      // hide tab with all articles
+// hide tab with all articles
       allTab.classList.remove("show");
       allTab.classList.remove("active");
-    } else {
-      /* if we've selected a pill that is currently selected, undo selection for it and its tab */
+    } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
       selectedPill.classList.remove("selected");
       selectedPill.classList.remove("active");
 
@@ -24,12 +31,12 @@ layout: default
       selectedTab.classList.remove("show");
       selectedTab.classList.remove("active");
 
-      // show tab with all articles
+// show tab with all articles
       allTab.classList.add("show");
       allTab.classList.add("active");
     }
 
-    /* remove "selected" from all other pills */
+/* remove "selected" from all other pills */
     let pillSet = new Set(pills);
     pillSet.delete(selectedPill);
     pillSet.forEach(pill => pill.classList.remove("selected"));
@@ -37,7 +44,7 @@ layout: default
 </script>
 <h1>Press</h1>
 <ul
-  class="nav nav-pills mb-3 gap-2"
+  class="nav nav-pills mb-3 gap-2 hide-if-noscript"
   id="pills-tab"
   role="tablist">
   <li class="nav-item" role="presentation">
@@ -85,7 +92,7 @@ layout: default
       id="pills-all"
       role="tabpanel"
       tabindex="0">
-      {% include press_listing.html tag="" %}
+      {% include press_listing.html tag = "" %}
     </div>
     <div
       class="tab-pane fade"

--- a/src/press.html
+++ b/src/press.html
@@ -5,11 +5,16 @@ layout: default
 <script>
   function deselect(id) {
     const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
+    const allTab = document.querySelector("#pills-all");
 
     const selectedPill = document.querySelector("#" + id);
     if (!selectedPill.classList.contains("selected")) {
       /* mark it as selected */
       selectedPill.classList.add("selected");
+
+      // hide tab with all articles
+      allTab.classList.remove("show");
+      allTab.classList.remove("active");
     } else {
       /* if we've selected a pill that is currently selected, undo selection for it and its tab */
       selectedPill.classList.remove("selected");
@@ -18,6 +23,10 @@ layout: default
       const selectedTab = document.querySelector("div[aria-labelledby='" + id + "']")
       selectedTab.classList.remove("show");
       selectedTab.classList.remove("active");
+
+      // show tab with all articles
+      allTab.classList.add("show");
+      allTab.classList.add("active");
     }
 
     /* remove "selected" from all other pills */
@@ -40,7 +49,7 @@ layout: default
       type="button"
       role="tab"
       aria-controls="pills-contactless"
-      aria-selected="true"
+      aria-selected="false"
       onclick="deselect('pills-contactless-tab')">Contactless Payments</button>
   </li>
   <li class="nav-item" role="presentation">
@@ -71,6 +80,13 @@ layout: default
 
 <section id="press">
   <div class="tab-content" id="pills-tabContent">
+    <div
+      class="tab-pane fade active show"
+      id="pills-all"
+      role="tabpanel"
+      tabindex="0">
+      {% include press_listing.html tag="" %}
+    </div>
     <div
       class="tab-pane fade"
       id="pills-contactless"

--- a/src/press.html
+++ b/src/press.html
@@ -2,22 +2,98 @@
 layout: default
 ---
 
+<script>
+  function deselect(id) {
+    const pills = document.querySelectorAll("button[data-bs-toggle='pill']")
+
+    const selectedPill = document.querySelector("#" + id);
+    if (!selectedPill.classList.contains("selected")) {
+      /* mark it as selected */
+      selectedPill.classList.add("selected");
+    } else {
+      /* if we've selected a pill that is currently selected, undo selection for it and its tab */
+      selectedPill.classList.remove("selected");
+      selectedPill.classList.remove("active");
+
+      const selectedTab = document.querySelector("div[aria-labelledby='" + id + "']")
+      selectedTab.classList.remove("show");
+      selectedTab.classList.remove("active");
+    }
+
+    /* remove "selected" from all other pills */
+    let pillSet = new Set(pills);
+    pillSet.delete(selectedPill);
+    pillSet.forEach(pill => pill.classList.remove("selected"));
+  }
+</script>
 <h1>Press</h1>
+<ul
+  class="nav nav-pills mb-3 gap-2"
+  id="pills-tab"
+  role="tablist">
+  <li class="nav-item" role="presentation">
+    <button
+      class="nav-link"
+      id="pills-contactless-tab"
+      data-bs-toggle="pill"
+      data-bs-target="#pills-contactless"
+      type="button"
+      role="tab"
+      aria-controls="pills-contactless"
+      aria-selected="true"
+      onclick="deselect('pills-contactless-tab')">Contactless Payments</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button
+      class="nav-link"
+      id="pills-benefits-tab"
+      data-bs-toggle="pill"
+      data-bs-target="#pills-benefits"
+      type="button"
+      role="tab"
+      aria-controls="pills-benefits"
+      aria-selected="false"
+      onclick="deselect('pills-benefits-tab')">Benefits</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button
+      class="nav-link"
+      id="pills-gtfs-tab"
+      data-bs-toggle="pill"
+      data-bs-target="#pills-gtfs"
+      type="button"
+      role="tab"
+      aria-controls="pills-gtfs"
+      aria-selected="false"
+      onclick="deselect('pills-gtfs-tab')">GTFS</button>
+  </li>
+</ul>
 
 <section id="press">
-  {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
-  {% assign all_press = site.press | reverse %}
-  {% for press in all_press %}
-    {% assign url = press.url %}
-    {% if press.external %}
-      {% assign url = press.external %}
-    {% endif %}
-    <article class="press-item">
-      <a href="{{ url }}" {% if press.external %}target="_blank"{% endif %}>{{ press.title }}</a>
-      <br/>
-      <span class="tags">{{ press.tags | join: ", " }}</span>
-      |
-      {% include date.html date=press.date format = "%b %Y" %}
-    </article>
-  {% endfor %}
+  <div class="tab-content" id="pills-tabContent">
+    <div
+      class="tab-pane fade"
+      id="pills-contactless"
+      role="tabpanel"
+      aria-labelledby="pills-contactless-tab"
+      tabindex="0">
+      {% include press_listing.html tag = "Contactless Payments" %}
+    </div>
+    <div
+      class="tab-pane fade"
+      id="pills-benefits"
+      role="tabpanel"
+      aria-labelledby="pills-benefits-tab"
+      tabindex="0">
+      {% include press_listing.html tag = "Benefits" %}
+    </div>
+    <div
+      class="tab-pane fade"
+      id="pills-gtfs"
+      role="tabpanel"
+      aria-labelledby="pills-gtfs-tab"
+      tabindex="0">
+      {% include press_listing.html tag = "GTFS" %}
+    </div>
+  </div>
 </section>

--- a/src/press.html
+++ b/src/press.html
@@ -98,6 +98,18 @@ layout: default
       allTab.classList.remove("show");
       allTab.classList.remove("active");
     });
+    p.addEventListener('keyup', event => {
+      if (event.keyCode == 37 || event.keyCode == 38 || event.keyCode == 39 || event.keyCode == 40) {
+        if (!p.classList.contains("selected")) {
+          p.classList.add("selected");
+
+          let pillSet = new Set(pills);
+          pillSet.delete(p);
+          pillSet.forEach(pill => pill.classList.remove("selected"));
+        }
+
+      }
+    });
   });
 
 
@@ -108,6 +120,11 @@ layout: default
     const selectedPill = document.querySelector("#" + id);
     if (! selectedPill.classList.contains("selected")) { /* mark it as selected */
       selectedPill.classList.add("selected");
+
+/* remove "selected" from all other pills */
+      let pillSet = new Set(pills);
+      pillSet.delete(selectedPill);
+      pillSet.forEach(pill => pill.classList.remove("selected"));
     } else { /* if we've selected a pill that is currently selected, undo selection for it and its tab */
       selectedPill.classList.remove("selected");
       selectedPill.classList.remove("active");
@@ -120,10 +137,5 @@ layout: default
       allTab.classList.add("show");
       allTab.classList.add("active");
     }
-
-/* remove "selected" from all other pills */
-    let pillSet = new Set(pills);
-    pillSet.delete(selectedPill);
-    pillSet.forEach(pill => pill.classList.remove("selected"));
   }
 </script>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -501,3 +501,15 @@ p.important {
     max-width: 540px;
   }
 }
+
+.nav-pills {
+  --bs-nav-pills-border-radius: 19px;
+  --bs-nav-pills-link-active-color: #fff;
+  --bs-nav-pills-link-active-bg: #212121;
+}
+
+.nav-pills .nav-link {
+  padding: 0.23rem;
+  border: 2px solid #212121;
+  color: #212121;
+}


### PR DESCRIPTION
Opening this PR mainly just so others can play with the filtering on the preview site.

### Notes
This is a very rough proof-of-concept for how we could accomplish the filtering UX described in #90.

There is custom Javascript to handle the parts that Bootstrap doesn't provide. Those parts are
 - turning a filter off
 - showing/hiding a tab that contains all articles

I think the JS code can be cleaned up / simplified. Also, there are definitely parts in `press.html` that would make sense to extract out as includes.

#### Handling no Javascript situation
[Bootstrap's notes on disabled Javascript](https://getbootstrap.com/docs/5.3/getting-started/javascript/#disabled-javascript)

This PR roughly shows how we could hide the pills when Javascript is not available. The tab with all articles is what shows, so the user experience is appropriate I think.