### PR TITLE
Home Page: Convert bottom 2 components to Rhombus on Desktop

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,7 @@ layout: default
 </section>
 
 <section class="row justify-content-md-center mt-5 mb-5 pb-5 rhombus-parent">
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 rounded rounded-4 text-center rhombus-2">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 text-center rhombus-2">
     <picture><img
         src="images/connect.png"
         alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
@@ -149,7 +149,7 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 mt-2 col-md-4 col-12 rounded rounded-4 text-center rhombus-3">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 mt-2 col-md-4 col-12 text-center rhombus-3">
     <picture><img
         src="images/stay-up-to-date.png"
         alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"

--- a/src/index.html
+++ b/src/index.html
@@ -125,12 +125,12 @@ layout: default
   </div>
 </section>
 
-<section class="row justify-content-md-center mt-5 mb-5 pb-5">
-  <div class="background-slate-5 shadow p-3 p-md-4 col-md-4 col-12 rounded rounded-4 text-center">
+<section class="row justify-content-md-center mt-5 mb-5 pb-5 rhombus-parent">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 rounded rounded-4 text-center rhombus-2">
     <picture><img
         src="images/connect.png"
         alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
-        width="80" /></picture>
+        width="105" /></picture>
     <h3 class="text-white d-block my-4">Connect with Cal-ITP</h3>
     <span class="text-white">Drop us a line at
       <a
@@ -149,13 +149,13 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 shadow p-4 col-md-4 col-12 rounded rounded-4 text-center">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 mt-2 col-md-4 col-12 rounded rounded-4 text-center rhombus-3">
     <picture><img
         src="images/stay-up-to-date.png"
         alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
-        width="80" /></picture>
-    <h3 class="text-white d-block my-4">Stay up to date</h3>
-    <p class="text-white text-start">
+        width="86" /></picture>
+    <h3 class="text-white d-block mt-3 mb-4">Stay up to date</h3>
+    <p class="text-white text-start ps-lg-3">
       See our
       <a
         class="text-white"

--- a/src/index.html
+++ b/src/index.html
@@ -158,12 +158,12 @@ layout: default
     <p class="text-white text-start ps-lg-3">
       See our
       <a
-        class="text-white"
+        class="text-white fw-bolder"
         href="https://dot.ca.gov/cal-itp"
         rel="noreferrer"
         target="_blank">latest milestones</a>, and subscribe to the
       <a
-        class="text-white"
+        class="text-white fw-bolder"
         href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website"
         rel="noreferrer"
         target="_blank">Caltrans Mobility Newsletter</a>, a free biweekly resource with frequent Cal-ITP project updates.

--- a/src/index.html
+++ b/src/index.html
@@ -149,7 +149,7 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 mt-2 col-md-4 col-12 text-center rhombus-3">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center rhombus-3">
     <picture><img
         src="images/stay-up-to-date.png"
         alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -382,6 +382,14 @@ p.important {
   .rhombus-1 {
     clip-path: polygon(0 3%, 100% 0, 96% 98%, 3% 100%);
   }
+
+  .rhombus-2 {
+    clip-path: polygon(8% 10%, 91% 0, 100% 100%, 0 100%);
+  }
+
+  .rhombus-3 {
+    clip-path: polygon(0 0, 100% 9%, 100% 100%, 7% 100%);
+  }
 }
 
 @media (max-width: 992px) {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -384,7 +384,7 @@ p.important {
   }
 
   .rhombus-2 {
-    clip-path: polygon(8% 10%, 91% 0, 100% 100%, 0 100%);
+    clip-path: polygon(8% 10%, 91% 2.5%, 100% 100%, 0 100%);
   }
 
   .rhombus-3 {


### PR DESCRIPTION
closes #96 

This is the last Rhombus ticket!

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/d476ab4d-f990-4c26-9849-23d5efc9eee0">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/b8b615e0-be01-4190-879a-6dd8f0f1b350">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/f1d0238c-41b2-4d8e-8a72-f3b1bebf5517">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/3e460c9c-c0e0-469c-89db-80a2ea27825c">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/1453a9ff-7e1f-448a-9dee-b4a8ec6e9092">
