### PR TITLE
Fix header's home and reach out links

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -21,10 +21,7 @@
       <div class="navbar-collapse collapse justify-content-end" id="mainNav">
         <ul class="navbar-nav mb-0">
           <li class="nav-item">
-            <a
-              class="h4 mb-0 nav-link active"
-              aria-current="page"
-              href="#">About the project</a>
+            <a class="h4 mb-0 nav-link" href="/">About the project</a>
           </li>
           <li class="nav-item">
             <a class="h4 mb-0 nav-link" href="{% link resources.html %}">Resources</a>
@@ -33,7 +30,7 @@
             <a class="h4 mb-0 nav-link" href="{% link press.html %}">Press</a>
           </li>
           <li class="nav-item">
-            <a class="h4 mb-0 nav-link" href="#">Reach out</a>
+            <a class="h4 mb-0 nav-link" href="/#reachout">Reach out</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
closes #158 

## What this PR does
- Fixes: `About the project` link
- Fixes: `Reach out` link`

## How to test
- Click `About the project` from Press and Resources page
- Click `Reach out` link from Press and Resources page, Home page