### PR TITLE
Feat: article tabs

### DIFF
--- a/src/_includes/articles.html
+++ b/src/_includes/articles.html
@@ -1,3 +1,5 @@
 {% for item in items %}
-  {% include article.html item=item %}
+  {% if include.tag == empty or include.tag and press.tags contains include.tag %}
+    {% include article.html item=item %}
+  {% endif %}
 {% endfor %}

--- a/src/_includes/articles.html
+++ b/src/_includes/articles.html
@@ -1,5 +1,5 @@
 {% for item in items %}
-  {% if include.tag == empty or include.tag and press.tags contains include.tag %}
+  {% if include.tag == empty or include.tag and item.tags contains include.tag %}
     {% include article.html item=item %}
   {% endif %}
 {% endfor %}

--- a/src/press.html
+++ b/src/press.html
@@ -13,6 +13,41 @@ permalink: /press
         target="_blank"
         class="fw-bolder text-white"
         href="mailto:hello@calitp.org">hello@calitp.org</a>.</span></p>
+        <ul class="nav nav-pills mb-3 gap-2" id="pills-tab" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-contactless-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-contactless"
+              type="button"
+              role="tab"
+              aria-controls="pills-contactless"
+              aria-selected="false">Contactless Payments</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-benefits-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-benefits"
+              type="button"
+              role="tab"
+              aria-controls="pills-benefits"
+              aria-selected="false">Benefits</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-gtfs-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-gtfs"
+              type="button"
+              role="tab"
+              aria-controls="pills-gtfs"
+              aria-selected="false">GTFS</button>
+          </li>
+        </ul>
       </div>
     </div>
   </div>
@@ -30,6 +65,30 @@ permalink: /press
           role="tabpanel"
           tabindex="0">
         {% include articles.html items=items tag = "" %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-contactless"
+          role="tabpanel"
+          aria-labelledby="pills-contactless-tab"
+          tabindex="0">
+        {% include articles.html items=items tag = "Contactless Payments" %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-benefits"
+          role="tabpanel"
+          aria-labelledby="pills-benefits-tab"
+          tabindex="0">
+        {% include articles.html items=items tag = "Benefits" %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-gtfs"
+          role="tabpanel"
+          aria-labelledby="pills-gtfs-tab"
+          tabindex="0">
+        {% include articles.html items=items tag = "GTFS" %}
         </div>
       </div>
     </div>

--- a/src/press.html
+++ b/src/press.html
@@ -60,7 +60,7 @@ permalink: /press
         {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
         {% assign items = site.press | reverse %}
         <div
-          class="tab-pane fade active show"
+          class="tab-pane fade"
           id="pills-all"
           role="tabpanel"
           tabindex="0">

--- a/src/press.html
+++ b/src/press.html
@@ -21,9 +21,17 @@ permalink: /press
 <section class="row justify-content-center" id="press">
   <div class="col-10">
     <div class="offset-md-2 col-md-8 mb-5 pb-5 col-10">
-      {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
-      {% assign items = site.press | reverse %}
-      {% include articles.html items=items %}
+      <div class="tab-content" id="pills-tabContent">
+        {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
+        {% assign items = site.press | reverse %}
+        <div
+          class="tab-pane fade active show"
+          id="pills-all"
+          role="tabpanel"
+          tabindex="0">
+        {% include articles.html items=items tag = "" %}
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/src/resources.html
+++ b/src/resources.html
@@ -27,14 +27,22 @@ permalink: /resources
       {% comment %} one more reverse when creating the groups to order ascending by name {% endcomment %}
       {% assign groups = all_resources | group_by: "category" | reverse %}
 
-      {% for group in groups %}
-        <h2 class="mb-4 mt-5">{{ group.name }}</h2>
-        {% assign items = group.items %}
-        {% include articles.html items=items %}
-        {% unless forloop.last %}
-          <hr class="mt-5" />
-        {% endunless %}
-      {% endfor %}
+      <div class="tab-content" id="pills-tabContent">
+        <div
+          class="tab-pane fade active show"
+          id="pills-all"
+          role="tabpanel"
+          tabindex="0">
+          {% for group in groups %}
+            <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+            {% assign items = group.items %}
+            {% include articles.html items=items tag = "" %}
+            {% unless forloop.last %}
+              <hr class="mt-5" />
+            {% endunless %}
+          {% endfor %}
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/src/resources.html
+++ b/src/resources.html
@@ -14,6 +14,44 @@ permalink: /resources
             target="_blank"
             class="fw-bolder text-white"
             href="mailto:hello@calitp.org">hello@calitp.org</a>.</p>
+        <ul
+          class="nav nav-pills mb-3 gap-2"
+          id="pills-tab"
+          role="tablist">
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-contactless-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-contactless"
+              type="button"
+              role="tab"
+              aria-controls="pills-contactless"
+              aria-selected="false">Contactless Payments</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-benefits-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-benefits"
+              type="button"
+              role="tab"
+              aria-controls="pills-benefits"
+              aria-selected="false">Benefits</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="pills-gtfs-tab"
+              data-bs-toggle="pill"
+              data-bs-target="#pills-gtfs"
+              type="button"
+              role="tab"
+              aria-controls="pills-gtfs"
+              aria-selected="false">GTFS</button>
+          </li>
+        </ul>
       </div>
     </div>
   </div>
@@ -37,6 +75,51 @@ permalink: /resources
             <h2 class="mb-4 mt-5">{{ group.name }}</h2>
             {% assign items = group.items %}
             {% include articles.html items=items tag = "" %}
+            {% unless forloop.last %}
+              <hr class="mt-5" />
+            {% endunless %}
+          {% endfor %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-contactless"
+          role="tabpanel"
+          aria-labelledby="pills-contactless-tab"
+          tabindex="0">
+          {% for group in groups %}
+            <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+            {% assign items = group.items %}
+            {% include articles.html items=items tag = "Contactless Payments" %}
+            {% unless forloop.last %}
+              <hr class="mt-5" />
+            {% endunless %}
+          {% endfor %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-benefits"
+          role="tabpanel"
+          aria-labelledby="pills-benefits-tab"
+          tabindex="0">
+          {% for group in groups %}
+            <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+            {% assign items = group.items %}
+            {% include articles.html items=items tag = "Benefits" %}
+            {% unless forloop.last %}
+              <hr class="mt-5" />
+            {% endunless %}
+          {% endfor %}
+        </div>
+        <div
+          class="tab-pane fade"
+          id="pills-gtfs"
+          role="tabpanel"
+          aria-labelledby="pills-gtfs-tab"
+          tabindex="0">
+          {% for group in groups %}
+            <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+            {% assign items = group.items %}
+            {% include articles.html items=items tag = "GTFS" %}
             {% unless forloop.last %}
               <hr class="mt-5" />
             {% endunless %}

--- a/src/resources.html
+++ b/src/resources.html
@@ -67,7 +67,7 @@ permalink: /resources
 
       <div class="tab-content" id="pills-tabContent">
         <div
-          class="tab-pane fade active show"
+          class="tab-pane fade"
           id="pills-all"
           role="tabpanel"
           tabindex="0">


### PR DESCRIPTION
Adds tabs to Press and Resource pages that contain articles based on tag.

~Note that this PR doesn't have logic to hide the tab with all articles, so it always appears.~ hiding the "all" tab for now

Part of #91 and #92 