### PR TITLE
CSS for Pills on Resources and Press

### DIFF
--- a/src/_includes/initiatives.html
+++ b/src/_includes/initiatives.html
@@ -2,7 +2,7 @@
   <div class="col-12 col-lg-6">
     <h2 class="h1 text-center text-lg-start">Explore our initiatives</h2>
   </div>
-  <div class="col-12 col-lg-6 d-flex justify-content-center justify-content-lg-end align-items-center">
+  <div class="col-12 col-lg-6 d-flex justify-content-center justify-content-lg-end align-items-center black-on-white">
     <ul
       class="nav nav-pills nav-fill mb-3 gap-2"
       id="pills-tab"

--- a/src/_includes/pills.html
+++ b/src/_includes/pills.html
@@ -1,0 +1,21 @@
+<div class="d-flex flex-column flex-md-row align-items-md-center white-on-color mt-md-4">
+  <span class="me-2 mb-3 mt-4 my-md-0 text-white">Filter by:</span>
+  <ul
+    class="nav nav-pills gap-2"
+    id="pills-tab"
+    role="tablist">
+    {% for tag in site.data.resource_tags %}
+      <li class="nav-item" role="presentation">
+        <button
+          class="nav-link"
+          id="pills-{{ tag.id }}-tab"
+          data-bs-toggle="pill"
+          data-bs-target="#pills-{{ tag.id }}"
+          type="button"
+          role="tab"
+          aria-controls="pills-{{ tag.id }}"
+          aria-selected="false">{{ tag.name }}</button>
+      </li>
+    {% endfor %}
+  </ul>
+</div>

--- a/src/_includes/pills.html
+++ b/src/_includes/pills.html
@@ -4,7 +4,7 @@
     class="nav nav-pills gap-2"
     id="pills-tab"
     role="tablist">
-    {% for tag in site.data.resource_tags %}
+    {% for tag in include.tags %}
       <li class="nav-item" role="presentation">
         <button
           class="nav-link"

--- a/src/_includes/pills.html
+++ b/src/_includes/pills.html
@@ -1,7 +1,7 @@
 <div class="d-flex flex-column flex-md-row align-items-md-center white-on-color mt-md-4">
-  <span class="me-2 mb-3 mt-4 my-md-0 text-white">Filter by:</span>
+  <span class="me-2 mb-3 mt-4 my-md-0 text-white flex-shrink-0">Filter by:</span>
   <ul
-    class="nav nav-pills gap-2"
+    class="nav nav-pills gap-2 d-flex flex-column flex-md-row flex-shrink-0"
     id="pills-tab"
     role="tablist">
     {% for tag in include.tags %}

--- a/src/press.html
+++ b/src/press.html
@@ -13,21 +13,7 @@ permalink: /press
         target="_blank"
         class="fw-bolder text-white"
         href="mailto:hello@calitp.org">hello@calitp.org</a>.</span></p>
-        <ul class="nav nav-pills mb-3 gap-2" id="pills-tab" role="tablist">
-          {% for tag in site.data.press_tags %}
-            <li class="nav-item" role="presentation">
-            <button
-              class="nav-link"
-              id="pills-{{ tag.id }}-tab"
-              data-bs-toggle="pill"
-              data-bs-target="#pills-{{ tag.id }}"
-              type="button"
-              role="tab"
-              aria-controls="pills-{{ tag.id }}"
-              aria-selected="false">{{ tag.name }}</button>
-          </li>
-          {% endfor %}
-        </ul>
+        {% include pills.html %}
       </div>
     </div>
   </div>
@@ -46,7 +32,7 @@ permalink: /press
           tabindex="0">
         {% include articles.html items=items tag = "" %}
         </div>
-        {% for tag in site.data.press_tags %}
+        {% for tag in press_tags %}
           <div
             class="tab-pane fade"
             id="pills-{{ tag.id }}"

--- a/src/press.html
+++ b/src/press.html
@@ -13,7 +13,7 @@ permalink: /press
         target="_blank"
         class="fw-bolder text-white"
         href="mailto:hello@calitp.org">hello@calitp.org</a>.</span></p>
-        {% include pills.html %}
+        {% include pills.html tags=site.data.press_tags %}
       </div>
     </div>
   </div>

--- a/src/press.html
+++ b/src/press.html
@@ -32,7 +32,7 @@ permalink: /press
           tabindex="0">
         {% include articles.html items=items tag = "" %}
         </div>
-        {% for tag in press_tags %}
+        {% for tag in site.data.press_tags %}
           <div
             class="tab-pane fade"
             id="pills-{{ tag.id }}"

--- a/src/resources.html
+++ b/src/resources.html
@@ -14,7 +14,7 @@ permalink: /resources
             target="_blank"
             class="fw-bolder text-white"
             href="mailto:hello@calitp.org">hello@calitp.org</a>.</p>
-        {% include pills.html %}
+        {% include pills.html tags=site.data.resource_tags %}
       </div>
     </div>
   </div>

--- a/src/resources.html
+++ b/src/resources.html
@@ -14,24 +14,7 @@ permalink: /resources
             target="_blank"
             class="fw-bolder text-white"
             href="mailto:hello@calitp.org">hello@calitp.org</a>.</p>
-        <ul
-          class="nav nav-pills mb-3 gap-2"
-          id="pills-tab"
-          role="tablist">
-          {% for tag in site.data.resource_tags %}
-            <li class="nav-item" role="presentation">
-              <button
-                class="nav-link"
-                id="pills-{{ tag.id }}-tab"
-                data-bs-toggle="pill"
-                data-bs-target="#pills-{{ tag.id  }}"
-                type="button"
-                role="tab"
-                aria-controls="pills-{{ tag.id }}"
-                aria-selected="false">{{ tag.name }}</button>
-            </li>
-          {% endfor %}
-        </ul>
+        {% include pills.html %}
       </div>
     </div>
   </div>
@@ -62,20 +45,20 @@ permalink: /resources
         </div>
         {% for tag in site.data.resource_tags %}
           <div
-          class="tab-pane fade"
-          id="pills-{{ tag.id }}"
-          role="tabpanel"
-          aria-labelledby="pills-{{ tag.id }}-tab"
-          tabindex="0">
-          {% for group in groups %}
-            <h2 class="mb-4 mt-5">{{ group.name }}</h2>
-            {% assign items = group.items %}
-            {% include articles.html items=items tag = tag.name %}
-            {% unless forloop.last %}
-              <hr class="mt-5" />
-            {% endunless %}
-          {% endfor %}
-        </div>
+            class="tab-pane fade"
+            id="pills-{{ tag.id }}"
+            role="tabpanel"
+            aria-labelledby="pills-{{ tag.id }}-tab"
+            tabindex="0">
+            {% for group in groups %}
+              <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+              {% assign items = group.items %}
+              {% include articles.html items=items tag = tag.name %}
+              {% unless forloop.last %}
+                <hr class="mt-5" />
+              {% endunless %}
+            {% endfor %}
+          </div>
         {% endfor %}
       </div>
     </div>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -146,11 +146,11 @@ a:hover {
   --bs-nav-link-hover-color: var(--calitp-primary-blue);
 }
 
-.nav-link {
+header .nav-link {
   padding: 31.4px 0 31.4px 0;
 }
 
-.nav-link:hover {
+header .nav-link:hover {
   background-color: var(--calitp-background-blue);
 }
 
@@ -269,26 +269,46 @@ footer nav .links {
 
 .nav-pills {
   --bs-nav-pills-border-radius: 19px;
-  --bs-nav-pills-link-active-color: var(--bs-white);
-  --bs-nav-pills-link-active-bg: var(--bs-body-color);
 }
 
 .nav-pills .nav-link {
   padding: 0.23rem;
-  border: 2px solid var(--bs-body-color);
-  color: var(--bs-body-color);
+  border-width: 2px;
+  border-style: solid;
 }
 
-.nav-pills {
-  --bs-nav-pills-border-radius: 19px;
+.black-on-white .nav-pills {
   --bs-nav-pills-link-active-color: var(--bs-white);
   --bs-nav-pills-link-active-bg: var(--bs-body-color);
 }
 
-.nav-pills .nav-link {
-  padding: 0.23rem;
-  border: 2px solid var(--bs-body-color);
+.black-on-white .nav-pills .nav-link {
+  border-color: var(--bs-body-color);
+}
+
+.black-on-white .nav-pills .nav-link:not(.active) {
   color: var(--bs-body-color);
+}
+
+.black-on-white .nav-pills .nav-link:hover {
+  border-color: rgba(33, 33, 33, 0.8);
+}
+
+.white-on-color .nav-pills {
+  --bs-nav-pills-link-active-color: var(--bs-body-color);
+  --bs-nav-pills-link-active-bg: var(--bs-white);
+}
+
+.white-on-color .nav-pills .nav-link {
+  border-color: var(--bs-white);
+}
+
+.white-on-color .nav-pills .nav-link:not(.active) {
+  color: var(--bs-white);
+}
+
+.white-on-color .nav-pills .nav-link:hover {
+  border-color: rgba(var(--bs-white-rgb), 0.8);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
closes #92 
closes #91 
closes #88 

## What this PR does
- Create 2 new CSS classes `black-on-white` and `white-on-color` that governs the colors of Nav Pills
- Use `black-on-white` for home page and `white-on-color` on Press and Resources
- Create `includes` for the Nav Pills on Press and Resources page

## Screenshots

### Press & Resources
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/dd2ca3f3-2805-4be3-8073-1e80689bf03c">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/cf9fdd2b-1f75-4747-abdd-6c143d7eddc7">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/13fa506f-ae8e-4027-a887-9d40bf51b792">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/566c92b3-2ada-42f7-8a8a-8f036f6c1300">


### Home
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/13bd4452-dc49-456a-bd95-40a4159ca342">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/9b1062bf-4d5b-4e2e-86aa-06356de8bed7">
