### PR TITLE
Fix: pill padding

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -241,7 +241,7 @@ footer nav .links a:hover {
 }
 
 .nav-pills .nav-link {
-  padding: 0.23rem;
+  padding: 4px 8px;
   border-width: 2px;
   border-style: solid;
 }


### PR DESCRIPTION
Closes #168 

Figma shows the padding as `padding: 4px 8px`. Pixels are fine here since we don't need it to grow with the user's default font size.

![image](https://github.com/cal-itp/calitp.org/assets/25497886/193b8379-e0a1-46af-b862-615ba25a51b6)
