### PR TITLE
Fix: fix rhombus Safari issue on mobile widths

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -165,13 +165,14 @@ footer nav .links a:hover {
 /* Shared */
 
 .rhombus-parent {
-  filter: url("#rounded");
-  overflow: hidden;
-  z-index: 1;
+  filter: none;
+  clip-path: none;
 }
 
-.rhombus-1 {
-  clip-path: none;
+.rhombus-1,
+.rhombus-2,
+.rhombus-3 {
+  border-radius: 1.25rem;
 }
 
 /* Press Release */
@@ -295,6 +296,12 @@ footer nav .links a:hover {
     --bs-nav-link-color: var(--bs-body-color);
     --bs-navbar-nav-link-padding-y: 0;
     --bs-nav-link-padding-y: 0;
+  }
+
+  .rhombus-parent {
+    filter: url("#rounded");
+    overflow: hidden;
+    z-index: 1;
   }
 
   .rhombus-1 {


### PR DESCRIPTION
closes #174 

This PR fixes the rhombus issue on all pages on Safari mobile. Desktop still being investigated and will be fixed in a PR after this.

## Testing

### Apple/Mac/iPhone testers
- Test on Desktop at mobile width
- Test on Mobile Safari with the test Netlify link
- Test on iOS Emulator app on Desktop
- Test home page, press, resources

### Windows/Android testers
- Ensure no regressions

## Screenshots
All mobile widths (which means mobile width on Desktop too.. and also Safari mobile):
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/e61cf28e-74c4-4baa-bf30-3cd09238106b">
<img width="489" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/774d7a45-dabc-4534-862b-1421d5b9dae9">

