### PR TITLE
Refactor: avoid generating empty sections

### DIFF
--- a/src/_includes/articles.html
+++ b/src/_includes/articles.html
@@ -1,5 +1,3 @@
 {% for item in items %}
-  {% if include.tag == empty or include.tag and item.tags contains include.tag %}
-    {% include article.html item=item %}
-  {% endif %}
+  {% include article.html item=item %}
 {% endfor %}

--- a/src/press.html
+++ b/src/press.html
@@ -26,20 +26,21 @@ permalink: /press
         {% comment %} Jekyll sorts by the date field in ascending order by default {% endcomment %}
         {% assign items = site.press | reverse %}
         <div
-          class="tab-pane fade active show"
-          id="pills-all"
-          role="tabpanel"
-          tabindex="0">
-        {% include articles.html items=items tag = "" %}
+        class="tab-pane fade active show"
+        id="pills-all"
+        role="tabpanel"
+        tabindex="0">
+        {% include articles.html items=items %}
         </div>
         {% for tag in site.data.press_tags %}
+          {% assign items = site.press | reverse | where_exp: "item", "item.tags contains tag.name" %}
           <div
             class="tab-pane fade"
             id="pills-{{ tag.id }}"
             role="tabpanel"
             aria-labelledby="pills-{{ tag.id }}-tab"
             tabindex="0">
-          {% include articles.html items=items tag = tag.name %}
+          {% include articles.html items=items %}
           </div>
         {% endfor %}
         </div>

--- a/src/resources.html
+++ b/src/resources.html
@@ -37,7 +37,7 @@ permalink: /resources
           {% for group in groups %}
             <h2 class="mb-4 mt-5">{{ group.name }}</h2>
             {% assign items = group.items %}
-            {% include articles.html items=items tag = "" %}
+            {% include articles.html items=items %}
             {% unless forloop.last %}
               <hr class="mt-5" />
             {% endunless %}
@@ -51,11 +51,13 @@ permalink: /resources
             aria-labelledby="pills-{{ tag.id }}-tab"
             tabindex="0">
             {% for group in groups %}
-              <h2 class="mb-4 mt-5">{{ group.name }}</h2>
-              {% assign items = group.items %}
-              {% include articles.html items=items tag = tag.name %}
-              {% unless forloop.last %}
-                <hr class="mt-5" />
+              {% assign items = group.items | where_exp: "item", "item.tags contains tag.name" %}
+              {% unless items.size == 0 %}
+                <h2 class="mb-4 mt-5">{{ group.name }}</h2>
+                {% include articles.html items=items %}
+                {% unless forloop.last %}
+                  <hr class="mt-5" />
+                {% endunless %}
               {% endunless %}
             {% endfor %}
           </div>


### PR DESCRIPTION
Closes #173 

Moves the filtering logic up to the assignment of the `items` variable. This way the page can check the number of items if it needs to.