### PR TITLE
Fix: Fix Desktop rhombus bug on Safari

### DIFF
--- a/src/_includes/clipped.html
+++ b/src/_includes/clipped.html
@@ -1,0 +1,3 @@
+<svg class="position-absolute">
+  <clipPath id="my-clip-path" clipPathUnits="objectBoundingBox"><path d="M0,0.081 C-0.001,0.051,0.007,0.026,0.018,0.026 L0.981,0 C0.992,0,1,0.025,1,0.055 L0.981,0.902 C0.981,0.928,0.973,0.949,0.963,0.95 L0.042,1 C0.033,1,0.025,0.98,0.024,0.953 L0,0.081"></path></clipPath>
+</svg>

--- a/src/_includes/initiatives.html
+++ b/src/_includes/initiatives.html
@@ -1,3 +1,7 @@
+<svg class="position-absolute">
+  <clipPath id="my-clip-path" clipPathUnits="objectBoundingBox"><path d="M0,0.048 C0,0.036,0.008,0.025,0.018,0.025 L0.982,0 C0.992,0,1,0.011,1,0.023 L0.979,0.931 C0.979,0.942,0.972,0.952,0.962,0.953 L0.048,1 C0.038,1,0.029,0.991,0.029,0.979 L0,0.048"></path></clipPath>
+</svg>
+
 <div class="row d-flex justify-content-between">
   <div class="col-12 col-lg-6">
     <h2 class="h1 text-center text-lg-start">Explore our initiatives</h2>
@@ -27,14 +31,14 @@
 <div class="tab-content " id="pills-tabContent">
   {% for initiative in site.data.initiatives %}
     <div
-      class="tab-pane fade rhombus-parent {{ initiative.active }}"
+      class="tab-pane fade {{ initiative.active }}"
       id="pills-{{ initiative.slug }}"
       role="tabpanel"
       aria-labelledby="pills-{{ initiative.slug }}-tab"
       tabindex="0">
       <div
         id="{{ initiative.id }}"
-        class="px-5 px-md-3 py-5 my-4 rhombus-1"
+        class="px-5 px-md-3 py-5 my-4 clipped"
         style=" background-color: var({{ initiative.class }})">
         <div class="row pt-5">
           <picture class="col-12 col-md-2 col-lg-2 offset-md-1 d-flex justify-content-md-end align-self-md-start justify-content-center">

--- a/src/index.html
+++ b/src/index.html
@@ -150,7 +150,7 @@ layout: default
 </svg>
 
 <section class="row justify-content-md-center mt-5 mb-5 pb-5 ">
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 text-center clipped-start">
+  <div class="background-slate-5 pt-3 pt-md-5 px-3 col-md-4 col-12 text-center clipped-start">
     <picture><img
         src="images/connect.png"
         alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
@@ -173,7 +173,7 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center clipped-end">
+  <div class="background-slate-5 pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center clipped-end">
     <picture><img
         src="images/stay-up-to-date.png"
         alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"

--- a/src/index.html
+++ b/src/index.html
@@ -150,47 +150,51 @@ layout: default
 </svg>
 
 <section class="row justify-content-md-center mt-5 mb-5 pb-5 ">
-  <div class="background-slate-5 pt-3 pt-md-5 px-3 col-md-4 col-12 text-center clipped-start">
-    <picture><img
-        src="images/connect.png"
-        alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
-        width="105" /></picture>
-    <h3 class="text-white d-block my-4">Connect with Cal-ITP</h3>
-    <span class="text-white">Drop us a line at
-      <a
-        rel="noreferrer"
-        target="_blank"
-        class="fw-bolder text-white"
-        href="mailto:hello@calitp.org">hello@calitp.org</a>
-      to:</span>
-    <ul class="text-center ms-2 ms-md-4 ms-lg-5">
-      <li class="text-white text-start">request technical assistance</li>
-      <li class="text-white text-start">get more information</li>
-      <li class="text-white text-start">offer collaborative support</li>
-      <li class="text-white text-start">join our email list for updates</li>
-    </ul>
+  <div class="col-12 col-md-4" style="filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));">
+    <div class="background-slate-5 pt-3 pt-md-5 px-3 pb-1 text-center clipped-start">
+      <picture><img
+          src="images/connect.png"
+          alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
+          width="105" /></picture>
+      <h3 class="text-white d-block my-4">Connect with Cal-ITP</h3>
+      <span class="text-white">Drop us a line at
+        <a
+          rel="noreferrer"
+          target="_blank"
+          class="fw-bolder text-white"
+          href="mailto:hello@calitp.org">hello@calitp.org</a>
+        to:</span>
+      <ul class="text-center ms-2 ms-md-4 ms-lg-5">
+        <li class="text-white text-start">request technical assistance</li>
+        <li class="text-white text-start">get more information</li>
+        <li class="text-white text-start">offer collaborative support</li>
+        <li class="text-white text-start">join our email list for updates</li>
+      </ul>
+    </div>
   </div>
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center clipped-end">
-    <picture><img
-        src="images/stay-up-to-date.png"
-        alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
-        width="86" /></picture>
-    <h3 class="text-white d-block mt-3 mb-4">Stay up to date</h3>
-    <p class="text-white text-start ps-lg-3">
-      See our
-      <a
-        class="text-white fw-bolder"
-        href="https://dot.ca.gov/cal-itp"
-        rel="noreferrer"
-        target="_blank">latest milestones</a>, and subscribe to the
-      <a
-        class="text-white fw-bolder"
-        href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website"
-        rel="noreferrer"
-        target="_blank">Caltrans Mobility Newsletter</a>, a free biweekly resource with frequent Cal-ITP project updates.
-    </p>
+  <div class="col-12 col-md-4" style="filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));">
+    <div class="background-slate-5 pt-3 pt-md-5 px-md-5 px-3 pt-2 pb-3 text-center clipped-end">
+      <picture><img
+          src="images/stay-up-to-date.png"
+          alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
+          width="86" /></picture>
+      <h3 class="text-white d-block mt-3 mb-4">Stay up to date</h3>
+      <p class="text-white text-start ps-lg-4">
+        See our
+        <a
+          class="text-white fw-bolder"
+          href="https://dot.ca.gov/cal-itp"
+          rel="noreferrer"
+          target="_blank">latest milestones</a>, and subscribe to the
+        <a
+          class="text-white fw-bolder"
+          href="https://lp.constantcontactpages.com/su/eLbtFoE/calitp?website"
+          rel="noreferrer"
+          target="_blank">Caltrans Mobility Newsletter</a>, a free biweekly resource with frequent Cal-ITP project updates.
+      </p>
+    </div>
   </div>
 </section>

--- a/src/index.html
+++ b/src/index.html
@@ -141,8 +141,16 @@ layout: default
   </div>
 </section>
 
-<section class="row justify-content-md-center mt-5 mb-5 pb-5 rhombus-parent">
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 text-center rhombus-2">
+<svg class="position-absolute">
+  <clipPath id="my-clip-path-start" clipPathUnits="objectBoundingBox"><path d="M0.004,0.075 C0,0.034,0.029,0,0.066,0.002 L0.947,0.051 C0.979,0.052,1,0.081,1,0.116 V0.936 C1,0.973,0.977,1,0.944,1 H0.147 C0.117,1,0.091,0.977,0.088,0.943 L0.004,0.075"></path></clipPath>
+</svg>
+
+<svg class="position-absolute">
+  <clipPath id="my-clip-path-end" clipPathUnits="objectBoundingBox"><path d="M0.041,0.125 C0.043,0.092,0.066,0.066,0.096,0.063 L0.878,0 C0.91,-0.003,0.939,0.024,0.941,0.06 L1,0.929 C1,0.967,0.977,1,0.942,1 H0.061 C0.027,1,0,0.968,0.002,0.931 L0.041,0.125"></path></clipPath>
+</svg>
+
+<section class="row justify-content-md-center mt-5 mb-5 pb-5 ">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-3 col-md-4 col-12 text-center clipped-start">
     <picture><img
         src="images/connect.png"
         alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
@@ -165,7 +173,7 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center rhombus-3">
+  <div class="background-slate-5 shadow pt-3 pt-md-5 px-md-5 px-3 col-md-4 col-12 text-center clipped-end">
     <picture><img
         src="images/stay-up-to-date.png"
         alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
@@ -186,5 +194,3 @@ layout: default
     </p>
   </div>
 </section>
-
-{% include rounded.html %}

--- a/src/index.html
+++ b/src/index.html
@@ -149,9 +149,9 @@ layout: default
   <clipPath id="my-clip-path-end" clipPathUnits="objectBoundingBox"><path d="M0.041,0.125 C0.043,0.092,0.066,0.066,0.096,0.063 L0.878,0 C0.91,-0.003,0.939,0.024,0.941,0.06 L1,0.929 C1,0.967,0.977,1,0.942,1 H0.061 C0.027,1,0,0.968,0.002,0.931 L0.041,0.125"></path></clipPath>
 </svg>
 
-<section class="row justify-content-md-center mt-5 mb-5 pb-5 ">
-  <div class="col-12 col-md-4" style="filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));">
-    <div class="background-slate-5 pt-3 pt-md-5 px-3 pb-1 text-center clipped-start">
+<section class="row justify-content-md-center mt-5 mb-5 pb-5 align-content-stretch">
+  <div class="col-12 col-md-4 clipped-shadow">
+    <div class="background-slate-5 pt-3 pt-md-5 px-3 text-center clipped-end">
       <picture><img
           src="images/connect.png"
           alt="Two thought bubbles with dashes of various lengths, meant to represent words in a conversation"
@@ -175,14 +175,14 @@ layout: default
   <div class="col-md-auto">
     &nbsp;
   </div>
-  <div class="col-12 col-md-4" style="filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));">
-    <div class="background-slate-5 pt-3 pt-md-5 px-md-5 px-3 pt-2 pb-3 text-center clipped-end">
+  <div class="col-12 col-md-4 clipped-shadow">
+    <div class="background-slate-5 pt-3 pt-md-5 px-md-5 px-3 pt-2 text-center clipped-start">
       <picture><img
           src="images/stay-up-to-date.png"
           alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
           width="86" /></picture>
       <h3 class="text-white d-block mt-3 mb-4">Stay up to date</h3>
-      <p class="text-white text-start ps-lg-4">
+      <p class="text-white text-start ps-lg-3">
         See our
         <a
           class="text-white fw-bolder"

--- a/src/press.html
+++ b/src/press.html
@@ -3,18 +3,18 @@ layout: default
 permalink: /press
 ---
 
-<div class="rhombus-parent">
-  <div class="row justify-content-center">
-    <div class="background-calitp-blue rhombus-1 mt-5 mb-4 col-10 py-5 px-4 px-md-0">
-      <div class="offset-md-2 col-md-8 py-5 px-4 px-md-0">
-        <h1 class="text-white">Press</h1>
-        <p class="text-white">Below you’ll find news about Cal-ITP and our initiatives, including press releases and media coverage about new launches and project milestones. Interested in getting in touch? Reach out to us at <a
-        rel="noreferrer"
-        target="_blank"
-        class="fw-bolder text-white"
-        href="mailto:hello@calitp.org">hello@calitp.org</a>.</span></p>
-        {% include pills.html tags=site.data.press_tags %}
-      </div>
+{% include clipped.html %}
+
+<div class="row justify-content-center">
+  <div class="clipped background-calitp-blue rhombus-1 mt-5 mb-4 col-10 py-5 px-4 px-md-0">
+    <div class="offset-md-2 col-md-8 py-5 px-4 px-md-0">
+      <h1 class="text-white">Press</h1>
+      <p class="text-white">Below you’ll find news about Cal-ITP and our initiatives, including press releases and media coverage about new launches and project milestones. Interested in getting in touch? Reach out to us at <a
+      rel="noreferrer"
+      target="_blank"
+      class="fw-bolder text-white"
+      href="mailto:hello@calitp.org">hello@calitp.org</a>.</span></p>
+      {% include pills.html tags=site.data.press_tags %}
     </div>
   </div>
 </div>

--- a/src/resources.html
+++ b/src/resources.html
@@ -3,19 +3,19 @@ layout: default
 permalink: /resources
 ---
 
-<div class="rhombus-parent">
-  <div class="row justify-content-center">
-    <div class="background-purple-4 mt-5 mb-4 col-10 py-5 px-4 px-md-0 rhombus-1">
-      <div class="offset-md-2 col-md-8 py-5 px-4 px-md-0">
-        <h1 class="text-white">Resources</h1>
-        <p class="text-white">Below you’ll find information about Cal-ITP and our initiatives, including fact sheets, case studies, and more. Don’t see what you’re looking for? Reach out to us at
-          <a
-            rel="noreferrer"
-            target="_blank"
-            class="fw-bolder text-white"
-            href="mailto:hello@calitp.org">hello@calitp.org</a>.</p>
-        {% include pills.html tags=site.data.resource_tags %}
-      </div>
+{% include clipped.html %}
+
+<div class="row justify-content-center">
+  <div class="clipped background-purple-4 mt-5 mb-4 col-10 py-5 px-4 px-md-0 rhombus-1">
+    <div class="offset-md-2 col-md-8 py-5 px-4 px-md-0">
+      <h1 class="text-white">Resources</h1>
+      <p class="text-white">Below you’ll find information about Cal-ITP and our initiatives, including fact sheets, case studies, and more. Don’t see what you’re looking for? Reach out to us at
+        <a
+          rel="noreferrer"
+          target="_blank"
+          class="fw-bolder text-white"
+          href="mailto:hello@calitp.org">hello@calitp.org</a>.</p>
+      {% include pills.html tags=site.data.resource_tags %}
     </div>
   </div>
 </div>
@@ -66,5 +66,3 @@ permalink: /resources
 </section>
 
 <script src="/scripts/pill-behavior.js"></script>
-
-{% include rounded.html %}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -276,6 +276,10 @@ footer nav .links a:hover {
   border-radius: 1.25rem;
 }
 
+.clipped-shadow {
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));
+}
+
 @media (min-width: 992px) {
   .navbar {
     --bs-navbar-nav-link-padding-x: 40px;

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -81,10 +81,6 @@ li {
   font-size: 1rem;
 }
 
-a {
-  -webkit-tap-highlight-color: transparent;
-}
-
 .small-caps {
   text-transform: uppercase;
   line-height: var(--bs-body-line-height);
@@ -113,8 +109,6 @@ a {
 
 a:hover {
   text-decoration-style: dotted;
-  filter: none;
-  -webkit-filter: none;
 }
 
 .red-link {
@@ -255,7 +249,6 @@ footer nav .links a:hover {
 
 .black-on-white .nav-pills .nav-link:hover {
   border-color: rgba(33, 33, 33, 0.8);
-  filter: none;
 }
 
 .white-on-color .nav-pills {
@@ -265,17 +258,14 @@ footer nav .links a:hover {
 
 .white-on-color .nav-pills .nav-link {
   border-color: var(--bs-white);
-  filter: none;
 }
 
 .white-on-color .nav-pills .nav-link:not(.active) {
   color: var(--bs-white);
-  filter: none;
 }
 
 .white-on-color .nav-pills .nav-link:hover {
   border-color: rgba(var(--bs-white-rgb), 0.8);
-  filter: none;
 }
 
 .clipped,

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -7,13 +7,6 @@
   --bs-border-style: dashed;
   --bs-body-line-height: 1.4;
   --header-nav-height: 110px;
-  --tw-translate-x: 0;
-  --tw-translate-y: 0;
-  --tw-rotate: 0;
-  --tw-skew-x: 0;
-  --tw-skew-y: 0;
-  --tw-scale-x: 1;
-  --tw-scale-y: 1;
 }
 
 body {
@@ -86,6 +79,10 @@ p,
 a,
 li {
   font-size: 1rem;
+}
+
+a {
+  -webkit-tap-highlight-color: transparent;
 }
 
 .small-caps {
@@ -169,20 +166,6 @@ main.container {
 
 footer nav .links a:hover {
   color: var(--calitp-gray-2) !important;
-}
-
-/* Shared */
-
-.rhombus-parent {
-  filter: none;
-  -webkit-filter: none;
-  clip-path: none;
-}
-
-.rhombus-1,
-.rhombus-2,
-.rhombus-3 {
-  border-radius: 1.25rem;
 }
 
 /* Press Release */
@@ -272,6 +255,7 @@ footer nav .links a:hover {
 
 .black-on-white .nav-pills .nav-link:hover {
   border-color: rgba(33, 33, 33, 0.8);
+  filter: none;
 }
 
 .white-on-color .nav-pills {
@@ -281,14 +265,25 @@ footer nav .links a:hover {
 
 .white-on-color .nav-pills .nav-link {
   border-color: var(--bs-white);
+  filter: none;
 }
 
 .white-on-color .nav-pills .nav-link:not(.active) {
   color: var(--bs-white);
+  filter: none;
 }
 
 .white-on-color .nav-pills .nav-link:hover {
   border-color: rgba(var(--bs-white-rgb), 0.8);
+  filter: none;
+}
+
+.clipped,
+.clipped-start,
+.clipped-end {
+  -webkit-clip-path: none;
+  clip-path: none;
+  border-radius: 1.25rem;
 }
 
 @media (min-width: 992px) {
@@ -308,27 +303,25 @@ footer nav .links a:hover {
     --bs-nav-link-padding-y: 0;
   }
 
-  .rhombus-parent {
-    filter: url("#rounded");
-    -webkit-filter: url("#rounded");
-    overflow: hidden;
-    z-index: 1;
-    transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x))
-      skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-    -webkit-transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate))
-      skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  .clipped,
+  .clipped-start,
+  .clipped-end {
+    border-radius: 0;
   }
 
-  .rhombus-1 {
-    clip-path: polygon(0 3%, 100% 0, 96% 98%, 3% 100%);
+  .clipped {
+    -webkit-clip-path: url(#my-clip-path);
+    clip-path: url(#my-clip-path);
   }
 
-  .rhombus-2 {
-    clip-path: polygon(8% 10%, 91% 2.5%, 100% 100%, 0 100%);
+  .clipped-start {
+    -webkit-clip-path: url(#my-clip-path-start);
+    clip-path: url(#my-clip-path-start);
   }
 
-  .rhombus-3 {
-    clip-path: polygon(0 0, 100% 9%, 100% 100%, 7% 100%);
+  .clipped-end {
+    -webkit-clip-path: url(#my-clip-path-end);
+    clip-path: url(#my-clip-path-end);
   }
 }
 

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -7,6 +7,13 @@
   --bs-border-style: dashed;
   --bs-body-line-height: 1.4;
   --header-nav-height: 110px;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
 }
 
 body {
@@ -109,6 +116,8 @@ a {
 
 a:hover {
   text-decoration-style: dotted;
+  filter: none;
+  -webkit-filter: none;
 }
 
 .red-link {
@@ -166,6 +175,7 @@ footer nav .links a:hover {
 
 .rhombus-parent {
   filter: none;
+  -webkit-filter: none;
   clip-path: none;
 }
 
@@ -300,8 +310,13 @@ footer nav .links a:hover {
 
   .rhombus-parent {
     filter: url("#rounded");
+    -webkit-filter: url("#rounded");
     overflow: hidden;
     z-index: 1;
+    transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x))
+      skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+    -webkit-transform: translate3d(var(--tw-translate-x), var(--tw-translate-y), 0) rotate(var(--tw-rotate))
+      skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
   }
 
   .rhombus-1 {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -276,6 +276,11 @@ footer nav .links a:hover {
   border-radius: 1.25rem;
 }
 
+.clipped-start,
+.clipped-end {
+  min-height: 100%;
+}
+
 .clipped-shadow {
   filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.15));
 }


### PR DESCRIPTION
closes #174 fully

- Used https://yoksel.github.io/relative-clip-path/ to create clip-paths directly from svg's from Figma. Tried using https://www.plantcss.com/css-clip-path-generator but the shapes were not coming out the same.
- Avoid use of `filter: url` entirely, b/c it's very buggy on Safari.
- Creates an includes for the Press and Resources SVG, as they use the same one.
- Adds SVGs in-line for all 3 Index page SVGs.
- Adds back box-shadow (using filter) on the bottom 2 rhombuses on Home page (https://css-tricks.com/using-box-shadows-and-clip-path-together/)
- This PR also fixes: the second point on #178

## How to test
- Apple/Mac OS: test on Safari, Firefox, Chrome for rhombus fixes
- Windows: test on Firefox, Chrome for no regressions
- Android: test on Chrome for no regressions
- iPhone: test on Safari for no regressions

## Before & After

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/4694acd8-1032-485b-9abf-bcef71c3ec98">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/dce0cd38-aa22-4b65-925e-2b47698a4740">
Safari behaves very strangely with `filter: url()` -- the browser is trying to apply the filter to _everything_, from the link hover effect, to even the way the user highlights the text. There is no way to apply the filter to just one element in Safari, the browser will apply it to every child element and even highlighted text. And there's no way to add another filter to undo a url filter.


|Before   | After  |
|---|---|
|<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/17c2318c-65a6-4d97-a652-281cb2be8cb5">|  <img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/bce367df-beb0-4728-849c-53d592079639"> |  
|Totally bonkers.   |Normal.|  



<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/d0dc75c4-c4af-45b3-b004-25283f5c1f46">

<img width="1168" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/cedf201d-802d-41a4-ac3d-403ef4717609">

