### PR TITLE
Fix: Press Release CSS, Resources line break

### DIFF
--- a/src/_layouts/press.html
+++ b/src/_layouts/press.html
@@ -21,7 +21,7 @@ layout: default
         {% if page.lead %}
           <p>{{ page.lead }}</p>
         {% endif %}
-        <hr class="mt-5 mb-5">
+        <hr/>
         <p class="d-block pb-2 text-uppercase fw-semibold">For immediate release</p>
         <p>{{ date | append: location | append: "—" | append: page.intro }}</p>
         {{ page.content }}

--- a/src/_layouts/press.html
+++ b/src/_layouts/press.html
@@ -21,7 +21,7 @@ layout: default
         {% if page.lead %}
           <p>{{ page.lead }}</p>
         {% endif %}
-        <hr class="mt-5 pb-5">
+        <hr class="mt-5 mb-5">
         <p class="d-block pb-2 text-uppercase fw-semibold">For immediate release</p>
         <p>{{ date | append: location | append: "—" | append: page.intro }}</p>
         {{ page.content }}

--- a/src/resources.html
+++ b/src/resources.html
@@ -39,7 +39,7 @@ permalink: /resources
             {% assign items = group.items %}
             {% include articles.html items=items %}
             {% unless forloop.last %}
-              <hr class="mt-5" />
+              <hr/>
             {% endunless %}
           {% endfor %}
         </div>
@@ -56,7 +56,7 @@ permalink: /resources
                 <h2 class="mb-4 mt-5">{{ group.name }}</h2>
                 {% include articles.html items=items %}
                 {% unless forloop.last %}
-                  <hr class="mt-5" />
+                  <hr/>
                 {% endunless %}
               {% endunless %}
             {% endfor %}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -176,11 +176,6 @@ footer nav .links a:hover {
 
 /* Press Release */
 
-.press-release a {
-  color: var(--calitp-primary-blue);
-  font-weight: var(--calitp-font-weight-bold);
-}
-
 .press-release h2,
 .press-release h3 {
   font-size: var(--bs-body-font-size);

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -81,6 +81,11 @@ li {
   font-size: 1rem;
 }
 
+hr {
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
 .small-caps {
   text-transform: uppercase;
   line-height: var(--bs-body-line-height);


### PR DESCRIPTION
Closes #171 and #172

- makes links on Press Release use same styling as all other links on the site
- makes line break use 40px for top and bottom margins, which is what Figma shows for all line breaks (`hr`)