### PR TITLE
fix(mobile): mobile nav link sizing is off, text now vertically centered

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -332,7 +332,7 @@ footer nav .links a:hover {
   }
 
   .navbar-nav .nav-link {
-    padding: 23.8px 0 28.8px 12px;
+    padding: 23.8px 0 23.8px 12px;
     border-bottom: 1px solid var(--calitp-cyan-1);
   }
 


### PR DESCRIPTION
This was a bug I just noticed while testing the app on my phone.

- Bug: On Mobile, the mobile nav links are not vertically centered. I think this was a CSS typo!

## Screenshots: Staging vs. PR
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/1039edb6-e58a-4ee0-b69d-a204281e5175">
