### PR TITLE
Fix: Home - Rhombus padding

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -164,7 +164,7 @@ layout: default
           class="fw-bolder text-white"
           href="mailto:hello@calitp.org">hello@calitp.org</a>
         to:</span>
-      <ul class="text-center ms-2 ms-md-4 ms-lg-5">
+      <ul class="text-center mb-4 ms-2 ms-md-4 ms-lg-5">
         <li class="text-white text-start">request technical assistance</li>
         <li class="text-white text-start">get more information</li>
         <li class="text-white text-start">offer collaborative support</li>
@@ -181,7 +181,7 @@ layout: default
           src="images/stay-up-to-date.png"
           alt="A bus nearly surrounded by a semicircular arrow, meant to indicate that transit content is being refreshed"
           width="86" /></picture>
-      <h3 class="text-white d-block mt-3 mb-4">Stay up to date</h3>
+      <h3 class="text-white d-block my-4">Stay up to date</h3>
       <p class="text-white text-start ps-lg-3">
         See our
         <a


### PR DESCRIPTION
closes #178 

This PR depends on #188 being closed first.

This PR makes 2 small changes:
1. Add `mb-4` (`margin-bottom: 24px`) to the 1st rhombus. The 2nd rhombus doesn't need any adjustment -- the combination of `align-items-stretch` and the `min-height: 100%` will force the 2nd rhombus to be the same height as the 1st (the taller one).
2. Change `h3` of the 2nd rhombus to match the first's, of `my-4` so that both `h3`'s and the text underneath start at the same vertical height

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/3fa836d3-8053-41e1-a55f-4fbde6411ff4">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/6d8a746c-455d-492b-8c45-9013121b9e8a">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/e955a500-5383-4a9e-894f-1d65e278288c">
