### PR TITLE
Fix: Make About link jump to About section

### DIFF
--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -21,7 +21,7 @@
       <div class="navbar-collapse collapse justify-content-end" id="mainNav">
         <ul class="navbar-nav mb-0">
           <li class="nav-item">
-            <a class="h4 mb-0 nav-link d-block" href="/">About the project</a>
+            <a class="h4 mb-0 nav-link d-block" href="/#about">About the project</a>
           </li>
           <li class="nav-item">
             <a class="h4 mb-0 nav-link d-block" href="{% link resources.html %}">Resources</a>

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -163,6 +163,11 @@ main.container {
   padding-top: var(--header-nav-height);
 }
 
+section#about {
+  padding-top: var(--header-nav-height);
+  margin-top: calc(-1 * var(--header-nav-height));
+}
+
 footer nav .links a:hover {
   color: var(--calitp-gray-2) !important;
 }


### PR DESCRIPTION
Closes #180 

OK this definitely feels a little hacky so I am wide open to feedback if there is a better way.

Simply linking to the `#about` section causes the navbar to slightly obscure the header:

![image](https://github.com/cal-itp/calitp.org/assets/1783439/450e2893-19f0-4612-89c7-6ef8f459a82b)

Based on a couple of SO posts:

* [Boostrap using fixed navbar and anchor tags to jump to sections](https://stackoverflow.com/a/17181529/453168) which talks about using padding and a corresponding negative margin to avoid the navbar overlap
* [How can I get a negative value of CSS variables](https://stackoverflow.com/a/48639938/453168) which talks about flipping a variable from positive to negative

I added a bit of CSS for this `section#about`, which (I think) gives the intended result:

**Desktop**

![image](https://github.com/cal-itp/calitp.org/assets/1783439/2cce8944-7c6c-4a1f-a79d-1049aae56452)

**Mobile**

![image](https://github.com/cal-itp/calitp.org/assets/1783439/478b5d64-5397-4029-bc31-8edb0626dff0)

