### PR TITLE
Fix: spacing for Initiatives press links

### DIFF
--- a/src/_includes/initiatives.html
+++ b/src/_includes/initiatives.html
@@ -73,7 +73,7 @@
                 {% if press.tags contains initiative.tag %}
                   <article class="press-item">
                     <a
-                      class="text-white fw-bold mb-2"
+                      class="text-white fw-bold mb-2 d-block"
                       rel="noreferrer"
                       href="{{ url }}"
                       {% if press.external %}target="_blank"{% endif %}>{{ press.title }}</a>


### PR DESCRIPTION
Closes #177 

[`b8f5517d`](https://github.com/cal-itp/calitp.org/commit/b8f5517d0bf7f5cbc04e19b4583c57037421c3e6#diff-aa29c099255bf0ab97be6a008965095465c8b9b14edb6865097a7ea026a97c2eR96) added `d-block` to resource links, and this needed to be applied to press links as well.

With `block` display, margin will have effect so we get the 8px from `mb-2`.

![image](https://github.com/cal-itp/calitp.org/assets/25497886/7f613275-4d16-4f76-b662-e9818edbf2c4)
