### PR TITLE
Fix: Footer issues

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -1,28 +1,28 @@
 <section class="bg-dark navbar">
   <footer class="container">
     <nav class="col-12">
-      <ul class="list-unstyled my-0 py-2 row row-column gap-md-4">
-        <li class="col-md-auto col-6 pb-md-0">
+      <ul class="list-unstyled row row-column gap-md-4 my-3 my-md-0">
+        <li class="col-md-auto col-6 mb-1 mb-md-0">
           <a
             class="fw-normal text-decoration-none text-white"
             rel="noreferrer"
             href="#">Back to top</a>
         </li>
-        <li class="col-md-auto col-6 pb-md-0">
+        <li class="col-md-auto col-6 mb-1 mb-md-0">
           <a
             class="fw-normal text-decoration-none text-white"
             rel="noreferrer"
             target="_blank"
             href="https://dot.ca.gov/privacy-policy">Privacy policy</a>
         </li>
-        <li class="col-md-auto col-12">
+        <li class="col-md-auto col-12 my-1 my-md-0">
           <a
             class="fw-normal text-decoration-none text-white"
             rel="noreferrer"
             target="_blank"
             href="https://www.ca.gov/use/">Conditions of use</a>
         </li>
-        <li class="col-md-auto col-12">
+        <li class="col-md-auto col-12 my-1 my-md-0">
           <a
             class="fw-normal text-decoration-none text-white"
             rel="noreferrer"

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -168,7 +168,7 @@ section#about {
   margin-top: calc(-1 * var(--header-nav-height));
 }
 
-footer nav .links a:hover {
+footer a:hover {
   color: var(--calitp-gray-2) !important;
 }
 

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -7,6 +7,7 @@
   --bs-border-style: dashed;
   --bs-body-line-height: 1.4;
   --header-nav-height: 110px;
+  --footer-nav-height: 39px;
 }
 
 body {
@@ -309,6 +310,14 @@ footer a:hover {
     --bs-nav-link-color: var(--bs-body-color);
     --bs-navbar-nav-link-padding-y: 0;
     --bs-nav-link-padding-y: 0;
+  }
+
+  main.container {
+    min-height: calc(100vh - var(--footer-nav-height));
+  }
+
+  footer a {
+    line-height: var(--footer-nav-height);
   }
 
   .clipped,


### PR DESCRIPTION
An assorted mix of footer-related fixes:

1. On your laptop, go to https://staging.calitp.org/press and click **GTFS** or **Benefits** - the footer comes off from the bottom of the page on desktop windows of a certain size. This is because there aren't enough Press release or Articles linked. In the meantime, this PR sets the `main.container` to be at least `calc(100vh - footer height)` so that the footer stays at the bottom.
2. The footer hover color wasn't working b/c of a CSS typo.
3. The spacing of the footer on mobile was a little off.