### PR TITLE
Press: Add new GTFS press release

### DIFF
--- a/src/_press/cal-itp-gtfs-schedule-validator.md
+++ b/src/_press/cal-itp-gtfs-schedule-validator.md
@@ -1,0 +1,7 @@
+---
+date: 2023-06-01
+title: New web tool makes GTFS validation easier for transit agency producers and consumers like journey-planning apps
+external: https://mobilitydata.org/new-web-based-version-of-gtfs-schedule-validator-released/
+tags:
+  - GTFS
+---


### PR DESCRIPTION
closes #179

Adds https://mobilitydata.org/new-web-based-version-of-gtfs-schedule-validator-released/ press release link to GTFS section, as requested by @esquared415 

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/7503b15d-96c6-474b-b9bc-475db916eb63">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/8ab5cd88-3791-4a84-87fa-a3618f9acb64">
