### PR TITLE
Fix: Initiatives section

### DIFF
--- a/src/_data/initiatives.yml
+++ b/src/_data/initiatives.yml
@@ -16,6 +16,7 @@
       target='_blank'>Monterey-Salinas Transit</a>, Cal-ITP and partners like Visa
       demonstrated how a transit provider that has traditionally used cash and agency-specific
       fare cards can accept contactless bank card payments like any other merchant. "
+    - "For more information about the products available to support this initiative, please visit the California Mobility Marketplace."
   button:
     text: Explore Mobility Marketplace
     url: https://camobilitymarketplace.org
@@ -45,6 +46,7 @@
   button:
     text: Explore Mobility Marketplace
     url: https://camobilitymarketplace.org
+    class: d-none
   class: --calitp-red-5
 - tag: GTFS
   slug: gtfs
@@ -67,4 +69,5 @@
   button:
     text: Explore Mobility Marketplace
     url: https://camobilitymarketplace.org
+    class: d-none
   class: --calitp-purple-4

--- a/src/_includes/initiatives.html
+++ b/src/_includes/initiatives.html
@@ -56,7 +56,7 @@
               </p>
             {% endfor %}
             <div class="d-grid d-md-block rounded-0 border-bottom border-white border-2">
-              <a href="{{ initiative.button.url }}" class="btn btn-outline-light fw-bolder mt-2 mb-28 mb-md-40">{{ initiative.button.text }}</a>
+              <a href="{{ initiative.button.url }}" class="btn btn-outline-light fw-bolder mt-2 mb-28 mb-md-40 {{ initiative.button.class }}">{{ initiative.button.text }}</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
fix #208 

- hide Mobi Mart button for GTFS, Benefits
- add pre-button text for Contactless Payments

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/c4e7150c-53c5-401b-b118-50c7d437bf4d">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/e4f5d0d4-68d9-4e87-81fd-7a628cfadb19">
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/c4edc003-c6f3-4b04-a382-ef968f5c46c9">

