### PR TITLE
Press Page: Add Outlet data to press item, show it on press page

### DIFF
--- a/src/_includes/article.html
+++ b/src/_includes/article.html
@@ -13,6 +13,6 @@
 <article class="d-block mb-3 pb-4">
   <a href="{{ url }}" {% if item.external %}target="_blank"{% endif %}>{{ item.title }}</a>
   <br/>
-  <span class="text-secondary font-poppins fs-7">{{ item.tags | join: ", " }} |
+  <span class="text-secondary font-poppins fs-7">{{ item.outlet }} | {{ item.tags | join: ", " }} |
     {% include date.html date=item.date format = "%b %Y" %}</span>
 </article>

--- a/src/_press/cal-itp-announces-ods.md
+++ b/src/_press/cal-itp-announces-ods.md
@@ -9,6 +9,7 @@ intro: |-
   information and extends it to include data about personnel, scheduled maintenance, and non-revenue service.
 tags:
   - GTFS
+outlet: "Cal-ITP"
 ---
 
 The ODS specification is a product of the Operational Data Standard Working Group, a coalition of more than 40 transit

--- a/src/_press/cal-itp-benefits-launch.md
+++ b/src/_press/cal-itp-benefits-launch.md
@@ -13,6 +13,7 @@ intro: |-
   a contactless debit or credit card to automatically receive reduced fares whenever they tap to pay with the card.
 tags:
   - Benefits
+outlet: "Cal-ITP"
 ---
 
 Cal-ITP Benefits is initially available for people 65 and older who ride Monterey-Salinas Transit (MST) buses, with plans to

--- a/src/_press/cal-itp-coast-rta-msa.md
+++ b/src/_press/cal-itp-coast-rta-msa.md
@@ -13,6 +13,7 @@ intro: |-
   payments.
 tags:
   - Contactless Payments
+outlet: "Cal-ITP"
 ---
 
 Cal-ITP—Caltrans’ California Integrated Travel Project—supported Coast RTA through the process of purchasing open-loop payment

--- a/src/_press/cal-itp-gtfs-schedule-validator.md
+++ b/src/_press/cal-itp-gtfs-schedule-validator.md
@@ -4,4 +4,5 @@ title: New web tool makes GTFS validation easier for transit agency producers an
 external: https://mobilitydata.org/new-web-based-version-of-gtfs-schedule-validator-released/
 tags:
   - GTFS
+outlet: "Cal-ITP"
 ---

--- a/src/_press/cal-itp-gtfs-schedule-validator.md
+++ b/src/_press/cal-itp-gtfs-schedule-validator.md
@@ -4,5 +4,5 @@ title: New web tool makes GTFS validation easier for transit agency producers an
 external: https://mobilitydata.org/new-web-based-version-of-gtfs-schedule-validator-released/
 tags:
   - GTFS
-outlet: "Cal-ITP"
+outlet: "MobilityData.org"
 ---

--- a/src/_press/cal-itp-payments-data-dashboard.md
+++ b/src/_press/cal-itp-payments-data-dashboard.md
@@ -4,5 +4,5 @@ title: Cal-ITP’s free dashboard serves up ridership metrics for transit agenci
 external: https://gcn.com/data-analytics/2023/01/caltrans-serves-dashboard-metrics-local-transit-agencies/381473/
 tags:
   - Contactless Payments
-outlet: "GCN.com"
+outlet: "Route Fifty"
 ---

--- a/src/_press/cal-itp-payments-data-dashboard.md
+++ b/src/_press/cal-itp-payments-data-dashboard.md
@@ -1,7 +1,7 @@
 ---
 date: 2023-01-04
 title: Cal-ITP’s free dashboard serves up ridership metrics for transit agencies
-external: https://gcn.com/data-analytics/2023/01/caltrans-serves-dashboard-metrics-local-transit-agencies/381473/
+external: https://www.route-fifty.com/digital-government/2023/01/caltrans-serves-dashboard-metrics-local-transit-agencies/381473/
 tags:
   - Contactless Payments
 outlet: "Route Fifty"

--- a/src/_press/cal-itp-payments-data-dashboard.md
+++ b/src/_press/cal-itp-payments-data-dashboard.md
@@ -4,4 +4,5 @@ title: Cal-ITP’s free dashboard serves up ridership metrics for transit agenci
 external: https://gcn.com/data-analytics/2023/01/caltrans-serves-dashboard-metrics-local-transit-agencies/381473/
 tags:
   - Contactless Payments
+outlet: "GCN.com"
 ---


### PR DESCRIPTION
closes #207 

- adds `outlet:` key value pair to each Press item, with either `Cal-ITP` for internal press releases or the name of the external media outlet
- show the outlet on the Press page, before the tag and dateline

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/9bbb3512-9647-4c02-a958-87bc2bd6359f">
