### PR TITLE
Fix: broken GitHub Action

### DIFF
--- a/.github/workflows/dependabot-differ.yaml
+++ b/.github/workflows/dependabot-differ.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout Default Branch
         uses: actions/checkout@v2
         with:
-          ref: core
+          ref: staging
           clean: false
           submodules: true
 


### PR DESCRIPTION
We'll have to update again once https://github.com/cal-itp/calitp.org/issues/80 is closed and the redesign is launched

This is why [this action is failing](https://github.com/cal-itp/calitp.org/actions/workflows/dependabot-differ.yaml) on all the recent PRs