### PR TITLE
Fix: Initiatives - only show top 3 resources, press

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -193,7 +193,8 @@ footer a:hover {
   max-width: 441px;
 }
 
-#details .tab-content .tab-list article:nth-child(n + 3) {
+.tab-list .press-item:nth-child(n + 4),
+.tab-list .resource:nth-child(n + 4) {
   display: none;
 }
 


### PR DESCRIPTION
fix #238 

- Only show the top 3 resources, top 3 press. Up to 3.

<img width="1379" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/4afcd3dd-a1a7-46ad-a7d2-be066657b71f">
<img width="1499" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/dcb497ee-734f-45e4-8670-5bba63d3990f">
