### PR TITLE
Fix: approval field options

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_press.yml
+++ b/.github/ISSUE_TEMPLATE/new_press.yml
@@ -14,8 +14,8 @@ body:
       description: Has your content (document and headline) been approved by @esquared415? If No, please allow 3-5 business days for review by Erika.
       multiple: false
       options:
-        - No
-        - Yes
+        - 'No'
+        - 'Yes'
   - type: input
     id: title
     validations:

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -14,8 +14,8 @@ body:
       description: Has your content (document and headline) been approved by @esquared415? If No, please allow 3-5 business days for review by Erika.
       multiple: false
       options:
-        - No
-        - Yes
+        - 'No'
+        - 'Yes'
   - type: input
     id: title
     attributes:


### PR DESCRIPTION
They cannot contain boolean values:

![image](https://github.com/cal-itp/calitp.org/assets/1783439/917a1b2c-0efe-40ae-95d0-de70b6341380)

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-options-must-not-include-booleans-please-wrap-values-such-as-yes-and-true-in-quotes
