### PR TITLE
Fix: page metadata

### DIFF
--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -16,30 +16,34 @@
   {%- assign description = site.description -%}
 {%- endif -%}
 {%- assign description = description | normalize_whitespace -%}
-
+{%- assign is_article = page.date and page.tags -%}
 <meta charset="utf-8" />
 <title>{{ title }}</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="description" content="{{ description }}" />
-{%- if page.date and page.tags -%}
+{%- if is_article -%}
   {%- for tag in page.tags -%}
     <meta property="article:tag" content="{{ tag }}" />
   {%- endfor -%}
   <meta property="article:published_time" content="{{ page.date | date: "%FT%T%z" }}" />
+{%- endif -%}
+<meta property="og:description" content="{{ description }}">
+<meta property="og:image" content="{{ site.url | absolute_url }}/images/og-image.png" />
+<meta property="og:locale" content="en_US">
+<meta property="og:site_name" content="{{ site.title }}">
+<meta property="og:title" content="{{ page_title }}" />
+{%- if is_article -%}
   <meta property="og:type" content="article">
 {%- else -%}
   <meta property="og:type" content="website">
 {%- endif -%}
-<meta property="og:locale" content="en_US">
-<meta property="og:site_name" content="{{ site.title }}">
-<meta property="og:title" content="{{ page_title }}" />
 <meta property="og:url" content="{{ page.url | absolute_url }}" />
-<meta property="og:image" content="{{ site.url | absolute_url }}/images/og-image.png" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:creator" content="@California_ITP">
-<meta name="twitter:description" content="{{description}}" />
+<meta name="twitter:description" content="{{ description }}" />
+<meta name="twitter:domain" content="{{ site.domain }}" />
 <meta name="twitter:image" content="{{ site.url | absolute_url }}/images/og-image.png" />
 <meta name="twitter:site" content="@California_ITP">
 <meta name="twitter:title" content="{{ page_title }}" />

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -6,10 +6,12 @@
   {%- assign title = site.title -%}
 {%- endif -%}
 
-{%- if page.description -%}
-  {%- assign description = page.description -%}
+{%- if page.lead -%}
+  {%- assign description = page.lead -%}
 {%- elsif page.intro -%}
   {%- assign description = page.intro -%}
+{%- elsif page.description -%}
+  {%- assign description = page.description -%}
 {%- else -%}
   {%- assign description = site.description -%}
 {%- endif -%}

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -1,17 +1,44 @@
-{% if include.title %} {% assign title=include.title|prepend=" - " %} {% else %} {% assign title="" %} {% endif %}
+{%- if page.title -%}
+  {%- assign page_title = page.title -%}
+  {%- assign title = page.title | append: " - " | append: site.title -%}
+{%- else -%}
+  {%- assign page_title = site.title -%}
+  {%- assign title = site.title -%}
+{%- endif -%}
+
+{%- if page.description -%}
+  {%- assign description = page.description -%}
+{%- elsif page.intro -%}
+  {%- assign description = page.intro -%}
+{%- else -%}
+  {%- assign description = site.description -%}
+{%- endif -%}
+{%- assign description = description | normalize_whitespace -%}
 
 <meta charset="utf-8" />
-<title>{{site.title}}{{title}}</title>
-<meta name="description" content="{{site.description}}" />
+<title>{{ title }}</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-<meta property="og:title" content="{{site.title}}" />
-<meta property="og:type" content="website" />
-<meta property="og:url" content="{{site.url}}" />
-<meta property="og:image" content="{{site.url}}/images/og-image.png" />
+<meta name="description" content="{{ description }}" />
+{%- if page.date and page.tags -%}
+  {%- for tag in page.tags -%}
+    <meta property="article:tag" content="{{ tag }}" />
+  {%- endfor -%}
+  <meta property="article:published_time" content="{{ page.date | date: "%FT%T%z" }}" />
+  <meta property="og:type" content="article">
+{%- else -%}
+  <meta property="og:type" content="website">
+{%- endif -%}
+<meta property="og:locale" content="en_US">
+<meta property="og:site_name" content="{{ site.title }}">
+<meta property="og:title" content="{{ page_title }}" />
+<meta property="og:url" content="{{ page.url | absolute_url }}" />
+<meta property="og:image" content="{{ site.url | absolute_url }}/images/og-image.png" />
 <meta name="twitter:card" content="summary_large_image" />
-<meta property="twitter:domain" content="{{site.domain}}" />
-<meta property="twitter:url" content="{{site.url}}" />
-<meta name="twitter:title" content="{{site.title}}" />
-<meta name="twitter:description" content="{{site.description}}" />
-<meta name="twitter:image" content="{{site.url}}/images/og-image.png" />
+<meta name="twitter:creator" content="@California_ITP">
+<meta name="twitter:description" content="{{description}}" />
+<meta name="twitter:image" content="{{ site.url | absolute_url }}/images/og-image.png" />
+<meta name="twitter:site" content="@California_ITP">
+<meta name="twitter:title" content="{{ page_title }}" />
+<meta name="twitter:url" content="{{ page.url | absolute_url }}" />

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 ---
-title: "Example"
+title: Home
 layout: default
 ---
 

--- a/src/press.html
+++ b/src/press.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 permalink: /press
+title: Press
 ---
 
 {% include clipped.html %}

--- a/src/resources.html
+++ b/src/resources.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 permalink: /resources
+title: Resources
 ---
 
 {% include clipped.html %}


### PR DESCRIPTION
Use individual page titles/descriptions, update `og` and other `<meta>` tags.

Closes #254 