### PR TITLE
Print-friendly site

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -1,4 +1,4 @@
-<section class="bg-dark navbar">
+<section class="bg-dark navbar d-print-none">
   <footer class="container">
     <nav class="col-12">
       <ul class="list-unstyled row row-column gap-md-4 my-3 my-md-0">

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -1,4 +1,4 @@
-<header>
+<header class="d-print-none">
   <nav class="navbar navbar-expand-lg fixed-top bg-white" aria-label="Navigation">
     <div class="container">
       <a class="navbar-brand" href="/">
@@ -37,3 +37,9 @@
     </div>
   </nav>
 </header>
+
+<img
+  class="d-none d-print-block"
+  src="/images/cal-itp-logo.svg"
+  alt="Cal-ITP: California Integrated Travel Project"
+  width="119" />

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -31,6 +31,21 @@ body {
   --calitp-font-weight-bold: 700;
 }
 
+@media print {
+  main.container {
+    padding-top: 1rem !important;
+  }
+
+  .col-lg-8 {
+    width: 100% !important;
+  }
+
+  .press-release p,
+  .press-release a {
+    font-size: 0.875rem !important;
+  }
+}
+
 .background-calitp-blue {
   background-color: var(--calitp-primary-blue);
 }


### PR DESCRIPTION
closes #137 

This PR makes any page on calitp.org more printer-friendly, by having a print mode-specific header, changing the font size and widening the width.

## This PR uses
- Print display classes: https://getbootstrap.com/docs/5.2/utilities/display/#display-in-print
- Print display media query: https://developer.mozilla.org/en-US/docs/Web/Guide/Printing

## How to test
- Use print preview: https://www.sitepoint.com/css-printer-friendly-pages/#testingprinteroutput
- Use DevTools: https://www.sitepoint.com/css-printer-friendly-pages/#testingprinteroutput



## Test PDF file
<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/004f7bcd-4d42-4076-9d6e-8eb520eaed66">

<img width="1512" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/194470e4-2ffd-4be3-808d-7fdfcc8c97fc">

- [Cal-ITP and partners celebrate major milestones in implementation of Operational Data Standard (ODS) for transit - Cal-ITP California Integrated Travel Project.pdf](https://github.com/cal-itp/calitp.org/files/12796289/Cal-ITP.and.partners.celebrate.major.milestones.in.implementation.of.Operational.Data.Standard.ODS.for.transit.-.Cal-ITP.California.Integrated.Travel.Project.pdf)


