### PR TITLE
Feat: Resources as HTML

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,13 +4,19 @@ collections:
     output: true
     permalink: /:collection/:name
   resources:
-    output: false
+    output: true
+    permalink: /:collection/:name
 defaults:
   - scope:
       path: ""
       type: press
     values:
       layout: press
+  - scope:
+      path: ""
+      type: resources
+    values:
+      layout: resource
 description: A state government initiative, Cal-ITP is making riding by rail and bus simpler and more cost-effective—for California transit providers and riders.
 domain: www.calitp.org
 google_fonts: "https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Raleway:wght@700&display=swap"

--- a/src/_includes/article.html
+++ b/src/_includes/article.html
@@ -1,8 +1,12 @@
 {% if item.category %}
-  {% assign url = item.asset %}
-  {% unless url contains "https://" %}
-    {% assign url = "/assets/" | append: url %}
-  {% endunless %}
+  {% if item.asset %}
+    {% assign url = item.asset %}
+    {% unless url contains "https://" %}
+      {% assign url = "/assets/" | append: url %}
+    {% endunless %}
+  {% else %}
+    {% assign url = item.url %}
+  {% endif %}
 {% else %}
   {% assign url = item.url %}
   {% if item.external %}

--- a/src/_layouts/resource.html
+++ b/src/_layouts/resource.html
@@ -1,0 +1,17 @@
+---
+layout: default
+---
+
+{% capture date %} {% include date.html date=page.date format = "%B %e, %Y" %} {% endcapture %}
+
+<div class="row justify-content-center">
+  <div class="col-lg-8 col-md-8">
+    <article class="press-release pb-5 mb-5">
+      <a class="d-block text-decoration-none mb-2 pt-3 mt-5 text-primary-blue" href="/resources">Resource</a>
+      <h1 class="h2">{{ page.title }}</h1>
+      <hr />
+      <p>{{ date }}</p>
+      {{ page.content }}
+    </article>
+  </div>
+</div>


### PR DESCRIPTION
Closes #267

This PR adds support for hosting Resource pages as HTML. 

To create the `resource` layout, I just copy-and-pasted from the `press` layout, and then I removed some things that don't apply to Resources. I referenced the resource from #266 to see what doesn't apply.

For testing purposes, I made a file at `src/_resources/test.md` with these contents:
```
---
date: "2022-11-01T17:00:00-07:00"
title: |-
  this is a test from Angela
category: Case studies
tags:
  - Contactless Payments
---

blah blah blah

**bold**

1. apples
1. bananas
1. carrots
```

and here's what it looks like:

![image](https://github.com/cal-itp/calitp.org/assets/25497886/e3a155da-5f42-4ca1-9baf-cb7679c65492)


Here is what the link to that HTML resource on the Resources page looks like:

![image](https://github.com/cal-itp/calitp.org/assets/25497886/1c3bedd6-baca-4149-8f0c-1e4ed62ad894)

