### PR TITLE
Update resource issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -91,7 +91,7 @@ body:
     attributes:
       label: Tag
       description: What tag is this resource in?
-      multiple: false
+      multiple: true
       options:
         - Contactless payments
         - Benefits

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -11,18 +11,10 @@ body:
       required: true
     attributes:
       label: Approved?
-      description: Has your content (document and headline) been approved by @esquared415? If No, please allow 3-5 business days for review by Erika.
-      multiple: false
+      description: Has your content (document and headline) been approved been approved for publication? If not, please confirm approval in #comms-and-content.
       options:
-        - 'No'
-        - 'Yes'
-  - type: input
-    id: title
-    attributes:
-      label: Title
-      description: The title is used in list views on the home page and [https://calitp.org/resources](https://calitp.org/resources)
-    validations:
-      required: true
+        - "No"
+        - "Yes"
   - type: checkboxes
     id: cat-preferences
     attributes:
@@ -35,37 +27,8 @@ body:
           required: true
         - label: Did you ensure there are no revision dates or numbers in the filename? Limit usage of revision numbers or dates unless commonly understood and expected by the audience. Avoid `report-june-2024.pdf`, `file-v1.2.pdf`. Allowed `GTFS-guidlines-v3.pdf`, as version 3 is an official version number.
           required: true
-        - label: Did you run this PDF through Adobe Acrobat's Accessibility Checker, and ensure the PDF passes all accessibility checks?
+        - label: Did you run this PDF through Adobe Acrobat's Accessibility Checker, and ensure the PDF passes all accessibility checks? Please review [this checklist](https://docs.google.com/document/d/1CkXfHDuJ4fR2wikGrsgyt4Dib6YdY3AhFmYtsk4kQXg/edit#heading=h.ecbzu7qezn59) to get more information on accessibility and how to run accessibility checks.
           required: true
-  - type: input
-    id: link
-    attributes:
-      label: Asset URL
-      description: The URL of the resource
-      placeholder: ex. link to a PDF from Google Drive
-    validations:
-      required: true
-  - type: dropdown
-    attributes:
-      label: Category
-      description: What category is this resource in?
-      multiple: false
-      options:
-        - Case studies
-        - Fact sheets & overviews
-    validations:
-      required: true
-  - type: dropdown
-    attributes:
-      label: Tag
-      description: What tag is this resource in?
-      multiple: false
-      options:
-        - Contactless payments
-        - Benefits
-        - GTFS
-    validations:
-      required: true
   - type: dropdown
     attributes:
       label: Date - Year
@@ -97,5 +60,41 @@ body:
         - "10"
         - "11"
         - "12"
+    validations:
+      required: true
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: The title is used in list views on the home page and [https://calitp.org/resources](https://calitp.org/resources)
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Asset URL
+      description: The URL of the resource
+      placeholder: ex. link to a PDF from Google Drive
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Category
+      description: What category is this resource in?
+      multiple: false
+      options:
+        - Case studies
+        - Fact sheets & overviews
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Tag
+      description: What tag is this resource in?
+      multiple: false
+      options:
+        - Contactless payments
+        - Benefits
+        - GTFS
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -90,7 +90,7 @@ body:
   - type: dropdown
     attributes:
       label: Tag
-      description: What tag is this resource in?
+      description: What tag is this resource in? (You may select more than one.)
       multiple: true
       options:
         - Contactless payments

--- a/.github/ISSUE_TEMPLATE/new_resource.yml
+++ b/.github/ISSUE_TEMPLATE/new_resource.yml
@@ -11,7 +11,7 @@ body:
       required: true
     attributes:
       label: Approved?
-      description: Has your content (document and headline) been approved been approved for publication? If not, please confirm approval in #comms-and-content.
+      description: Has your content (document and headline) been approved been approved for publication? If not, please confirm approval in [#comms-and-content](https://cal-itp.slack.com/archives/C01LVK0C4NS).
       options:
         - "No"
         - "Yes"


### PR DESCRIPTION
closes #307 

- changes approval section to ask for approval in Slack
- adds a11y instructions link
- re-orders the questions to be in the same order as how the markdown file asks for them (date, title, asset link, category, tags) -- makes it easier to code the file

I forked the repo and tested out this issue template YML on my fork here: https://github.com/machikoyasuda/calitp.org/issues/new?assignees=&labels=content%2Cresources&projects=&template=new_resource.yml&title=New+resource+request

<img width="984" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/b41ab4d4-39c0-4d18-9435-6f2e8758c6aa">
<img width="1022" alt="image" src="https://github.com/cal-itp/calitp.org/assets/3673236/f07ac4e4-c6ed-4aaf-9080-227e024edc6f">
