### PR TITLE
Feat: web-review team reviews content changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # default to web-admin team
 * @cal-itp/web-admin
+
+# web-review team reviews content changes
+src/*.html  @cal-itp/web-review
+src/**/*.md @cal-itp/web-review
+src/assets/ @cal-itp/web-review


### PR DESCRIPTION
Adding @cal-itp/web-review (currently just @mrose914) to `CODEOWNERS` for specific files / directories where the content lives.

This will make it possible to automatically assign review for changes to these files. And means we won't have to wait for another engineer to review simple content updates. Checking with you @mrose914 is that is OK? We typically request your review anyway :sweat_smile: 