### PR TITLE
Nav

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,14 @@ defaults:
 description: A state government initiative, Cal-ITP is making riding by rail and bus simpler and more cost-effective—for California transit providers and riders.
 domain: www.calitp.org
 google_fonts: "https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&family=Raleway:wght@700&display=swap"
+navigation:
+  header:
+    - name: Resources
+      url: /resources
+    - name: Press
+      url: /press
+    - name: Reach out
+      url: /#reachout
 source: ./src
 timezone: America/Los_Angeles
 title: "Cal-ITP: California Integrated Travel Project"

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ navigation:
     - name: Press
       url: /press
     - name: Reach out
-      url: /#reachout
+      url: mailto:hello@calitp.org
 source: ./src
 timezone: America/Los_Angeles
 title: "Cal-ITP: California Integrated Travel Project"

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -19,13 +19,8 @@
       <div class="navbar-collapse collapse justify-content-end" id="mainNav">
         <ul class="navbar-nav mb-0">
           <li class="nav-item">
-            <a class="h4 mb-0 nav-link d-block" href="{% link resources.html %}">Resources</a>
-          </li>
-          <li class="nav-item">
-            <a class="h4 mb-0 nav-link d-block" href="{% link press.html %}">Press</a>
-          </li>
-          <li class="nav-item">
-            <a class="h4 mb-0 nav-link d-block" href="/#reachout">Reach out</a>
+            {% include link_repeater.html menu_items=site.navigation.header anchor_class="dropdown-item h4 mb-0 nav-link d-block"
+            %}
           </li>
         </ul>
       </div>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -18,10 +18,8 @@
 
       <div class="navbar-collapse collapse justify-content-end" id="mainNav">
         <ul class="navbar-nav mb-0">
-          <li class="nav-item">
-            {% include link_repeater.html menu_items=site.navigation.header anchor_class="dropdown-item h4 mb-0 nav-link d-block"
-            %}
-          </li>
+          {% include link_repeater.html list_class="nav-item" menu_items=site.navigation.header anchor_class="nav-link h4 mb-0
+          d-block rounded-1" %}
         </ul>
       </div>
     </div>

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -2,10 +2,7 @@
   <nav class="navbar navbar-expand-lg fixed-top bg-white" aria-label="Navigation">
     <div class="container">
       <a class="navbar-brand" href="/">
-        <img
-          src="/images/cal-itp-logo.svg"
-          alt="Cal-ITP: California Integrated Travel Project"
-          width="119" />
+        <img src="/images/cal-itp-logo.svg" alt="Cal-ITP: California Integrated Travel Project" width="119" />
       </a>
       <button
         class="navbar-toggler collapsed"
@@ -14,15 +11,13 @@
         data-bs-target="#mainNav"
         aria-controls="mainNav"
         aria-expanded="false"
-        aria-label="Toggle navigation">
+        aria-label="Toggle navigation"
+      >
         <span class="navbar-toggler-icon"></span>
       </button>
 
       <div class="navbar-collapse collapse justify-content-end" id="mainNav">
         <ul class="navbar-nav mb-0">
-          <li class="nav-item">
-            <a class="h4 mb-0 nav-link d-block" href="/#about">About the project</a>
-          </li>
           <li class="nav-item">
             <a class="h4 mb-0 nav-link d-block" href="{% link resources.html %}">Resources</a>
           </li>
@@ -42,4 +37,5 @@
   class="d-none d-print-block"
   src="/images/cal-itp-logo.svg"
   alt="Cal-ITP: California Integrated Travel Project"
-  width="119" />
+  width="119"
+/>

--- a/src/_includes/link_repeater.html
+++ b/src/_includes/link_repeater.html
@@ -1,6 +1,6 @@
 {% for menu_item in include.menu_items %}
   {% assign current_page = page.url | replace: '/', '' %}
-  {% assign menu_url = menu_item.url | replace: '/', '' %}
+  {% assign menu_url = menu_item.url | replace: '/', '' | replace: '#reachout', '' %}
   <li class="{{ include.list_class | default: '' }}">
     <a
       href="{{ menu_item.url }}"

--- a/src/_includes/link_repeater.html
+++ b/src/_includes/link_repeater.html
@@ -1,6 +1,6 @@
 {% for menu_item in include.menu_items %}
   {% assign current_page = page.url | replace: '/', '' %}
-  {% assign menu_url = menu_item.url | replace: '/', '' | replace: '#reachout', '' %}
+  {% assign menu_url = menu_item.url | replace: '/', '' %}
   <li class="{{ include.list_class | default: '' }}">
     <a
       href="{{ menu_item.url }}"

--- a/src/_includes/link_repeater.html
+++ b/src/_includes/link_repeater.html
@@ -1,0 +1,14 @@
+{% for menu_item in include.menu_items %}
+  {% assign current_page = page.url | replace: '/', '' %}
+  {% assign menu_url = menu_item.url | replace: '/', '' %}
+  <li class="{{ include.list_class | default: '' }}">
+    <a
+      href="{{ menu_item.url }}"
+      class="{{ include.anchor_class | default: '' }}"
+      {% if menu_item.target %}target="{{ menu_item.target }}"{% endif %}
+      {% if menu_url == current_page %}aria-current="page"{% endif %}
+    >
+      {{ menu_item.name }}
+    </a>
+  </li>
+{% endfor %}

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -18,6 +18,7 @@ body {
   --calitp-primary-blue: rgb(4, 107, 153); /* #046b99 */
   --calitp-primary-dark-blue: rgb(34, 81, 115); /* #225173 */
   --calitp-background-blue: rgb(245, 249, 251); /* #F5F9FB */
+  --calitp-background-light-blue: rgb(223, 242, 242); /* #DFF2F2 */
   --calitp-cyan-1: rgb(213, 238, 245); /* #d5eef5 */
   --calitp-gray-2: rgb(200, 200, 201); /* #C8C8C9 */
   --calitp-green-4: rgb(0, 117, 91); /* #00755b */
@@ -171,8 +172,14 @@ header .nav-link {
   padding: 31.4px 0 31.4px 0;
 }
 
+.dropdown-item[aria-current="page"] {
+  color: var(--calitp-primary-blue);
+  background-color: var(--calitp-background-light-blue);
+  border-radius: 3px;
+}
+
 header .nav-link:hover {
-  background-color: var(--calitp-background-blue);
+  background-color: var(--calitp-background-light-blue);
 }
 
 main.container {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -176,12 +176,10 @@ header .nav-link {
 header .nav-link[aria-current="page"] {
   color: var(--calitp-primary-blue);
   background-color: var(--calitp-background-light-blue);
-  /* border-radius: 3px; */
 }
 
 header .nav-link:hover {
   background-color: var(--calitp-background-light-blue);
-  /* border-radius: 3px; */
 }
 
 main.container {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -172,7 +172,7 @@ header .nav-link {
   padding: 31.4px 0 31.4px 0;
 }
 
-.dropdown-item[aria-current="page"] {
+header .nav-link[aria-current="page"] {
   color: var(--calitp-primary-blue);
   background-color: var(--calitp-background-light-blue);
   border-radius: 3px;

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -166,6 +166,7 @@ a:hover {
   --bs-nav-link-color: var(--bs-body-color);
   --bs-navbar-active-color: var(--calitp-primary-blue);
   --bs-nav-link-hover-color: var(--calitp-primary-blue);
+  gap: 32px;
 }
 
 header .nav-link {
@@ -175,11 +176,12 @@ header .nav-link {
 header .nav-link[aria-current="page"] {
   color: var(--calitp-primary-blue);
   background-color: var(--calitp-background-light-blue);
-  border-radius: 3px;
+  /* border-radius: 3px; */
 }
 
 header .nav-link:hover {
   background-color: var(--calitp-background-light-blue);
+  /* border-radius: 3px; */
 }
 
 main.container {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -166,11 +166,10 @@ a:hover {
   --bs-nav-link-color: var(--bs-body-color);
   --bs-navbar-active-color: var(--calitp-primary-blue);
   --bs-nav-link-hover-color: var(--calitp-primary-blue);
-  gap: 32px;
 }
 
 header .nav-link {
-  padding: 31.4px 0 31.4px 0;
+  padding: 2rem 0;
 }
 
 header .nav-link[aria-current="page"] {
@@ -379,14 +378,15 @@ footer a:hover {
   }
 
   .navbar-brand {
-    --bs-navbar-brand-padding-x: 4rem;
-    --bs-navbar-brand-padding-y: 4rem;
+    --bs-navbar-brand-padding-x: 2rem;
+    --bs-navbar-brand-padding-y: 2rem;
   }
 
   .navbar-nav {
     --bs-nav-link-color: var(--bs-body-color);
     --bs-navbar-nav-link-padding-y: 0;
     --bs-nav-link-padding-y: 0;
+    gap: 2rem;
   }
 
   main.container {
@@ -421,8 +421,8 @@ footer a:hover {
 
 @media (max-width: 992px) {
   .navbar-brand {
-    --bs-navbar-brand-padding-x: 32px;
-    --bs-navbar-brand-padding-y: 32px;
+    --bs-navbar-brand-padding-x: 2rem;
+    --bs-navbar-brand-padding-y: 2rem;
   }
 
   #mainNav {

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -379,8 +379,8 @@ footer a:hover {
   }
 
   .navbar-brand {
-    --bs-navbar-brand-padding-x: 32px;
-    --bs-navbar-brand-padding-y: 32px;
+    --bs-navbar-brand-padding-x: 4rem;
+    --bs-navbar-brand-padding-y: 4rem;
   }
 
   .navbar-nav {


### PR DESCRIPTION
closes #350 

## What this PR does
- Puts the nav header links in the `config.yml` page
- Uses a `link-repeater.html` includes (similar to MobiMart) to set the aria current page
- Use aria current page to style the current page: When a user is on the Press or Resources page, the corresponding page name should be highlighted in the nav
- The Reach out link goes straight to a `mailto:hello@calitp.org` link

<img width="748" alt="image" src="https://github.com/user-attachments/assets/6e17b792-29c3-42d1-82a9-2cfb5d888f7d">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d4772194-163e-4ee4-8697-2516554f4e84">
