### PR TITLE
Update calitp blue and hover blue

### DIFF
--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -11,6 +11,8 @@
 }
 
 body {
+  --bs-primary: #045b86;
+  --bs-primary-rgb: 4, 91, 134;
   --bs-body-color: rgb(33, 33, 33); /* #212121 */
   --bs-link-color: rgb(4, 91, 134); /* #045B86, calitp-primary-blue */
   --bs-link-hover-color: rgb(4, 72, 105); /* #044869, calitp-primary-dark-blue */

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -12,11 +12,11 @@
 
 body {
   --bs-body-color: rgb(33, 33, 33); /* #212121 */
-  --bs-link-color: rgb(4, 107, 153); /* calitp-primary-blue */
-  --bs-link-hover-color: rgb(34, 81, 115); /* calitp-primary-dark-blue */
+  --bs-link-color: rgb(4, 91, 134); /* #045B86, calitp-primary-blue */
+  --bs-link-hover-color: rgb(4, 72, 105); /* #044869, calitp-primary-dark-blue */
   --bs-secondary-rgb: 143, 147, 153; /* calitp-gray-3 */
-  --calitp-primary-blue: rgb(4, 107, 153); /* #046b99 */
-  --calitp-primary-dark-blue: rgb(34, 81, 115); /* #225173 */
+  --calitp-primary-blue: rgb(4, 91, 134); /* #045B86 */
+  --calitp-primary-dark-blue: rgb(4, 72, 105); /* #044869, , calitp-primary-dark-blue */
   --calitp-background-blue: rgb(245, 249, 251); /* #F5F9FB */
   --calitp-background-light-blue: rgb(223, 242, 242); /* #DFF2F2 */
   --calitp-cyan-1: rgb(213, 238, 245); /* #d5eef5 */


### PR DESCRIPTION
fixes #365 

Updates the primary blue and primary hover blue to colors according to https://github.com/cal-itp/benefits/issues/1423#issuecomment-1601567969

- Links, link hover, menu link, Contact background, Initiatives background, Press background should all be updated.