### PR TITLE
Refactor: initiative pills change hash

### DIFF
--- a/src/scripts/initiatives.js
+++ b/src/scripts/initiatives.js
@@ -1,16 +1,25 @@
 window.addEventListener("load", () => {
   const triggerTabList = document.querySelectorAll("#pills-tab button");
-  triggerTabList.forEach((triggerEl) => {
-    const tabTrigger = new bootstrap.Tab(triggerEl);
 
+  triggerTabList.forEach((triggerEl) => {
     triggerEl.addEventListener("click", (event) => {
       event.preventDefault();
-      tabTrigger.show();
+      // update the window.location.hash with the clicked pill's target
+      window.location.hash = event.target.getAttribute("data-bs-target").replace("#", "");
     });
   });
 
-  if (window.location.hash.startsWith("#initiatives")) {
-    const triggerEl = document.querySelector("button[data-bs-target='" + window.location.hash + "']");
-    bootstrap.Tab.getInstance(triggerEl).show();
+  // watch for changes to the window.location.hash value
+  function checkInitiativesHash() {
+    if (window.location.hash.startsWith("#initiatives")) {
+      const triggerEl = document.querySelector("button[data-bs-target='" + window.location.hash + "']");
+      const tabTrigger = new bootstrap.Tab(triggerEl);
+      tabTrigger.show();
+    }
   }
+
+  window.onhashchange = checkInitiativesHash;
+
+  // call the function once on page load to check for the initial hash
+  checkInitiativesHash();
 });


### PR DESCRIPTION
Quick follow-up to #363

* Update the URL so it matches the initiative the user is looking at
* Logic that shows a pill's content is now tied to the hash being changed
* Inserts initiative content into user's history

## How to test

1. Run the app locally
2. Ensure the existing behavior of going directly to e.g. `http://localhost:4000/#initiatives-gtfs` still loads that pill content
3. Change pills
4. Observe the `window.location.hash` value update accordingly
5. Observe the associated pill content become visible
6. Click the back button
7. Observe the previous hash / pill content is visible

## Demos

<details>
<summary>Loading the page with a hash link</summary>

https://github.com/user-attachments/assets/382b3130-f173-459f-93b0-f68bbaab0a3d

</details>

<details>
<summary>Clicking pills and the back button</summary>


https://github.com/user-attachments/assets/19298fa6-a8c1-4123-a27e-9196a80c1c83

</details>