### PR TITLE
Contact: Fix headline size

### DIFF
--- a/src/_includes/contact.html
+++ b/src/_includes/contact.html
@@ -1,6 +1,6 @@
 <section id="reachout" class="row justify-content-center">
   <div class="col-12 col-md-8 col-lg-6">
-    <h2 class="h1 text-center text-md-start d-block mb-3">The time is now—reach out to learn more</h2>
+    <h2 class="h1-md text-center text-md-start d-block mb-3">The time is now—reach out to learn more</h2>
   </div>
 </section>
 

--- a/src/stylesheets/main.css
+++ b/src/stylesheets/main.css
@@ -347,6 +347,10 @@ footer a:hover {
 }
 
 @media (min-width: 992px) {
+  .h1-md {
+    font-size: calc(40rem / 16);
+  }
+
   .navbar {
     --bs-navbar-nav-link-padding-x: 40px;
     --bs-navbar-nav-link-padding-y: 0;


### PR DESCRIPTION
fixes #378 

The contact section's headline font should be:
- 40px on Desktop (a H1 size)
- 32px (which is 2rem) on Mobile (a H2 size)

Creates `h1-md` class which means "this type is h1 size on medium size widths and up". 