### PR TITLE
Fix: A11y - Use a darker contrast-compliant gray

### DIFF
--- a/src/_includes/article.html
+++ b/src/_includes/article.html
@@ -1,30 +1,12 @@
-{% if item.category %}
-  {% if item.asset %}
-    {% assign url = item.asset %}
-    {% unless url contains "https://" %}
-      {% assign url = "/assets/" | append: url %}
-    {% endunless %}
-  {% else %}
-    {% assign url = item.url %}
-  {% endif %}
-{% else %}
-  {% assign url = item.url %}
-  {% if item.external %}
-    {% assign url = item.external %}
-  {% endif %}
-{% endif %}
+{% if item.category %} {% if item.asset %} {% assign url = item.asset %} {% unless url contains "https://" %} {% assign url =
+"/assets/" | append: url %} {% endunless %} {% else %} {% assign url = item.url %} {% endif %} {% else %} {% assign url = item.url
+%} {% if item.external %} {% assign url = item.external %} {% endif %} {% endif %}
 
 <article class="d-block mb-3 pb-4">
-  <a
-    href="{{ url }}"
-    {% if item.external %}
-    target="_blank"
-    {% endif %}>{{ item.title }}</a>
-  <br/>
-  <span class="text-secondary font-poppins fs-7">
-    {% if item.outlet %}
-      {{ item.outlet }} |{% endif %}
-    {% if item.tags.size > 0 %}
-      {{ item.tags | join: ", " }} |{% endif %}
-    {% include date.html date=item.date format = "%b %Y" %}</span>
+  <a href="{{ url }}" {% if item.external %} target="_blank" {% endif %}>{{ item.title }}</a>
+  <br />
+  <span class="text-body-tertiary font-poppins fs-7">
+    {% if item.outlet %} {{ item.outlet }} |{% endif %} {% if item.tags.size > 0 %} {{ item.tags | join: ", " }} |{% endif %} {%
+    include date.html date=item.date format = "%b %Y" %}</span
+  >
 </article>


### PR DESCRIPTION
closes #389 

Use `tertiary-gray` instead of `seconday`:

<img width="797" alt="image" src="https://github.com/user-attachments/assets/498fd495-7ec3-4cc7-8260-9934cb2da616">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/b56c2bf6-ca43-41ee-930c-5fc7c5f8c6d9">

I'm going to keep the secondary variable for now, in case we use it for non-text things like borders, etc.