### PR TITLE
docs: update README with Analytics info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Once inside the devcontainer, you have the manually start the site:
 The site is running on <http://127.0.0.1>; check the VS Code _Ports_ tab for the exact port. Auto rebuild/reload will be active
 and will watch the site files for changes.
 
+## Analytics
+
+Site analytics is tracked by Google Analytics, version 4. Ask an administrator to grant you access.
+
 ## License
 
 Content (including graphics, images, video, documents, and text) in this repository is licensed under [CC-BY 4.0][content-license].


### PR DESCRIPTION
In tandem with this ticket in MobiMart, https://github.com/cal-itp/mobility-marketplace/pull/610/, wanted to use this PR to document:

- calitp.org is NOT sending data to Amplitude.
- calitp.org is being tracked by Google Analytics, version 4, with enhanced measurement turned on for outbound links, file downloads and more.
- adding a note in the README about this so new users know where to look for reporting.