### PR TITLE
Chore: update broken press link

### DIFF
--- a/src/_press/la-metro-cal-itp-mobility-wallet-prepaid-debit-card-south-la.md
+++ b/src/_press/la-metro-cal-itp-mobility-wallet-prepaid-debit-card-south-la.md
@@ -1,7 +1,7 @@
 ---
 date: "2023-07-31T17:00:00-07:00"
 title: LA Metro collaborates with Cal-ITP to introduce a Mobility Wallet, a prepaid debit card that lets South L.A. residents pay for their choice of transportation modes
-external: https://thesource.metro.net/2023/07/31/introducing-the-mobility-wallet-mw-a-collaborative-transportation-solution-for-residents-of-south-la/
+external: https://thesource.metro.net/introducing-the-mobility-wallet-mw-a-collaborative-transportation-solution-for-residents-of-south-la/
 tags:
   - Contactless Payments
 outlet: "L.A. Metro’s The Source Blog"


### PR DESCRIPTION
Metro moved their press release and our link broke.

Fixes #452 