### PR TITLE
fix: Instruct robots not to crawl resources with assets

### DIFF
--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -41,3 +41,6 @@
 <meta name="twitter:domain" content="{{ site.domain }}" />
 
 <link rel="canonical" href="{{ page.url | absolute_url }}" />
+{% if page.asset -%}
+  <meta name="robots" content="noindex">
+{%- endif -%}


### PR DESCRIPTION
Partially addresses #498

Will also need to ask Google to re-crawl these pages after this change is deployed in order to get them removed from the index. See: https://developers.google.com/search/docs/crawling-indexing/block-indexing#debugging-noindex-issues