### PR TITLE
chore: use shopify-liquid VS code plugin to autoformat html

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,10 +17,10 @@
       },
       "extensions": [
         "eamodio.gitlens",
-        "esbenp.prettier-vscode",
+        "prettier.prettier-vscode",
         "mhutchie.git-graph",
         "redhat.vscode-xml",
-        "sissel.shopify-liquid",
+        "shopify.theme-check-vscode",
         "streetsidesoftware.code-spell-checker",
         "tombi-toml.tombi"
       ]

--- a/.djlintrc
+++ b/.djlintrc
@@ -1,6 +1,0 @@
-{
-  "custom_blocks": "unless,capture",
-  "format_attribute_template_tags": true,
-  "indent": 2,
-  "max_blank_lines": 1
-}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,6 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=2500"]
 
-  - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
-    hooks:
-      - id: djlint-reformat-jinja
-        files: \.html$
-        types_or: ["html"]
-
   - repo: local
     hooks:
       - id: frontmatter-timestamp

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "printWidth": 130
+  "printWidth": 130,
+  "liquidSingleQuote": false,
+  "plugins": ["@shopify/prettier-plugin-liquid"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "cSpell.diagnosticLevelFlaggedWords": "Error",
   "cSpell.suggestionMenuType": "quickFix",
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "prettier.prettier-vscode",
   "files.encoding": "utf8",
   "files.eol": "\n",
   "files.insertFinalNewline": true,
@@ -14,7 +14,7 @@
     "*.html": "liquid"
   },
   "[liquid]": {
-    "editor.defaultFormatter": "sissel.shopify-liquid",
+    "editor.defaultFormatter": "Shopify.theme-check-vscode",
     "editor.formatOnSave": true
   }
 }

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -30,7 +30,7 @@
     <meta property="article:tag" content="{{ tag }}" />
   {%- endfor -%}
   <meta property="article:published_time"
-        content="{{ page.date | date: "%FT%T%z" }}" />
+        content="{{ page.date | date: '%FT%T%z' }}" />
 {%- endif -%}
 
 {% comment %} OpenGraph fields that won't be rendered by the jekyll-seo plugin {% endcomment %}

--- a/src/press.html
+++ b/src/press.html
@@ -17,7 +17,7 @@ description: >
       Below you’ll find news about Cal-ITP and our initiatives, including press releases and media coverage about new launches and project milestones. Interested in getting in touch? Reach out to us at <a rel="noreferrer"
     target="_blank"
     class="fw-bold text-white"
-    href="mailto:hello@calitp.org">hello@calitp.org</a>.</span>
+    href="mailto:hello@calitp.org">hello@calitp.org</a>.
     </p>
     {% include pills.html tags=site.data.press_tags %}
   </div>


### PR DESCRIPTION
resolves #541

* wires up prettier 3.x as the default autoformatter
* leans on the [Shopify liquid VS Code extension](https://shopify.dev/docs/storefronts/themes/tools/shopify-liquid-vscode) to format .html files
* abandons the djLint pre-commit step

theoretically it should be possible to get prettier + plugins configured to run via pre-commit, but i haven't found any joy getting that setup with `@shopify/prettier-plugin-liquid` yet (CIL for more notes about that).

https://github.com/prettier/pre-commit/issues/16

---

### dev notes

running the autoformatter on all files has uncovered two issues:
1. the prettier CLI formats differently than the VS Code extension, presumably because the plugin isn't invoked properly?
2. even autoformatting in VS Code results in output that jekyll can't compile.

i'm happy to poke at this more next week, but i'm leaning toward putting a pin in this work until we discuss https://github.com/cal-itp/mobility-marketplace/issues/736.
### ~alternatives explored~

~https://shopify.dev/docs/storefronts/themes/tools/shopify-liquid-vscode#code-formatting~

~i could only get ☝️ to autoformat `.liquid` files.~ 🤷