### PR TITLE
feat: Add spacing tokens and demo

### DIFF
--- a/src/dsdl.html
+++ b/src/dsdl.html
@@ -337,16 +337,6 @@ stylesheet: dsdl-demo.css
     <tbody>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-1px);">
-            <span class="visually-hidden">A box illustrating the size of something using spacing 1px</span>
-          </div>
-        </td>
-        <td>--spacing-1px</td>
-        <td>1px</td>
-        <td>N/A</td>
-      </tr>
-      <tr>
-        <td>
           <div class="spacing-sample" style="height: var(--spacing-05);">
             <span class="visually-hidden">A box illustrating the size of something using spacing 05 (half)</span>
           </div>
@@ -488,5 +478,7 @@ stylesheet: dsdl-demo.css
     </tbody>
     <caption class="visually-hidden">Chart of our spacing variables with visual reference</caption>
   </table>
+
+  <p>Note: For lines we want to be exactly 1 logical pixel without scaling, we use a <code>1px</code> value directly.</p>
 
 </div>

--- a/src/stylesheets/dsdl-demo.css
+++ b/src/stylesheets/dsdl-demo.css
@@ -41,10 +41,13 @@
   text-align: center;
 }
 
+.dsdl-demo table {
+  margin: var(--spacing-2) 0;
+}
 .dsdl-demo table th,
 .dsdl-demo table td {
   padding: var(--spacing-1);
-  border: var(--spacing-1px) solid var(--dsdl-gray-20);
+  border: 1px solid var(--dsdl-gray-20);
 }
 .dsdl-demo table th {
   background: var(--calitp-brand-blue);

--- a/src/stylesheets/dsdl/tokens.css
+++ b/src/stylesheets/dsdl/tokens.css
@@ -60,8 +60,6 @@
 /* SPACING */
 
 :root {
-  --spacing-1px: 1px;  /* Non-relative unit for when we don't want a single pixel stroke to scale */
-
   --spacing-base: calc(8 / var(--text-base) * 1rem);  /* 8px → 0.5rem */
   --spacing-05:   calc(var(--spacing-base) * 0.5);  /* 0.25rem (4px)   */
   --spacing-1:    calc(var(--spacing-base) * 1  );  /* 0.5rem  (8px)   */


### PR DESCRIPTION
Closes #550 

This PR adds spacing tokens to the DSDL CSS and adds a chart of them to the [demo page](https://deploy-preview-553--cal-itp-website.netlify.app/dsdl).

Review commit-by-commit to avoid seeing some minor cleanup until last.

### For discussion at some point

We currently use [Bootstrap's spacing utility classes](https://getbootstrap.com/docs/5.3/utilities/spacing/) extensively throughout our projects. This new 8px-based spacing system creates a tension with those in projects where we do not use Sass, because [there is not a CSS variable for overriding their base `$spacer`](https://getbootstrap.com/docs/5.3/customize/css-variables/) and [adding the additional increments we want would require overriding a Sass map](https://getbootstrap.com/docs/5.3/utilities/spacing/#sass-maps).

Generating our own custom spacing utilities would require a massive amount of work to cover all of the same functionality that Bootstrap's offer (margin + padding * six directional options * 14 increments).

The two options I see are:

1. Convert to Sass everywhere so we can override Bootstrap's Sass.
2. Lean away from using spacing utility classes and apply them via other CSS selectors.

(not necessarily in order of my preference – I'm not 100% sure yet which I think is best)