### PR TITLE
chore: Cap the weight of Noto Sans at 600

### DIFF
--- a/src/stylesheets/dsdl/core.css
+++ b/src/stylesheets/dsdl/core.css
@@ -10,15 +10,6 @@ body {
   line-height: var(--line-height-normal);
 }
 
-h1, .h1,
-h2, .h2,
-h3, .h3,
-h4, .h4,
-h5, .h5,
-h6, .h6 {
-  font-family: var(--dsdl-heading-font-stack);
-}
-
 .text-body-s {
   font-size: var(--text-xs);
   line-height: var(--line-height-loose);
@@ -144,11 +135,6 @@ a {
 a:hover,
 a:focus {
   color: var(--dsdl-blue-80);
-}
-
-b,
-strong {
-  font-weight: 600;
 }
 
 code,

--- a/src/stylesheets/dsdl/tokens.css
+++ b/src/stylesheets/dsdl/tokens.css
@@ -13,7 +13,7 @@
 /* Import webfonts */
 /* Space Grotesk: Variable weight, 400–700 */
 /* Source Code Pro: 400 only */
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400..800;1,400..800&family=Source+Code+Pro&family=Space+Grotesk:wght@400..700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400..600;1,400..600&family=Source+Code+Pro&family=Space+Grotesk:wght@400..700&display=swap');
 
 :root {
   /* Fonts */


### PR DESCRIPTION
Follow up to comments in #554 

- Caps the weight of Noto Sans at 600 (https://github.com/cal-itp/calitp.org/pull/554#discussion_r2612164507)
- Removes superfluous heading styles (https://github.com/cal-itp/calitp.org/pull/554#discussion_r2612164689)

I did some testing to show that the weight will not be artificially made bolder if attempted:

<img width="1760" height="696" alt="Table of all weight/style combinations for Noto Sans" src="https://github.com/user-attachments/assets/6a4e3984-ac85-47ca-bd40-79f9c42e175b" />

(tested in Firefox, Chrome, and Safari on macOS)