### PR TITLE
chore: update liquid-aware autoformatter

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,6 +1,0 @@
-{
-  "custom_blocks": "unless,capture",
-  "format_attribute_template_tags": true,
-  "indent": 2,
-  "max_blank_lines": 1
-}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,11 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=2500"]
 
-  - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+  - repo: https://github.com/JoC0de/pre-commit-prettier
+    rev: v3.8.1
     hooks:
-      - id: djlint-reformat-jinja
-        files: \.html$
-        types_or: ["html"]
+      - id: prettier
+        types_or: [css, html, liquid, markdown, yaml]
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,11 @@ repos:
     rev: v3.8.1
     hooks:
       - id: prettier
+        additional_dependencies:
+          - prettier@3.8.1
+          - "@shopify/prettier-plugin-liquid@1.10.2"
         types_or: [css, html, liquid, markdown, yaml]
+        stages: [commit-msg]
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v9.6.0

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "printWidth": 130
+  "printWidth": 130,
+  "plugins": ["@shopify/prettier-plugin-liquid"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,12 +9,5 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "editor.tabSize": 2,
-  "files.associations": {
-    "*.html": "liquid"
-  },
-  "[liquid]": {
-    "editor.defaultFormatter": "sissel.shopify-liquid",
-    "editor.formatOnSave": true
-  }
+  "editor.tabSize": 2
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
-        "@quasibit/eleventy-plugin-sitemap": "^2.0.0"
+        "@quasibit/eleventy-plugin-sitemap": "^2.0.0",
+        "@shopify/prettier-plugin-liquid": "^1.10.2",
+        "prettier": "^3.8.1"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -210,6 +212,31 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@shopify/liquid-html-parser": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@shopify/liquid-html-parser/-/liquid-html-parser-2.9.2.tgz",
+      "integrity": "sha512-2XJYqHaZxEBwuufGhzIZ0M6m9YA4HS7YlVOiZtYanFgkmoQeJm1c0JhKcuCXU5C1pc2M0rt1XzBX8SgWv7l8Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "line-column": "^1.0.2",
+        "ohm-js": "^17.0.0"
+      }
+    },
+    "node_modules/@shopify/prettier-plugin-liquid": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@shopify/prettier-plugin-liquid/-/prettier-plugin-liquid-1.10.2.tgz",
+      "integrity": "sha512-yzC+6bJemVnrEgddztLuX5I7zSoRrxXgS5j7BVS6HzVs9sMf8Fx+bdIEDkKu4bBBBKSzuen1SLVfq9u3z9L1wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shopify/liquid-html-parser": "^2.9.2",
+        "html-styles": "^1.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/@sindresorhus/slugify": {
@@ -863,6 +890,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/html-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/html-styles/-/html-styles-1.0.0.tgz",
+      "integrity": "sha512-cDl5dcj73oI4Hy0DSUNh54CAwslNLJRCCoO+RNkVo+sBrjA/0+7E/xzvj3zH/GxbbBLGJhE0hBe1eg+0FINC6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
@@ -1034,6 +1068,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iso-639-1": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.5.tgz",
@@ -1042,6 +1083,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-yaml": {
@@ -1085,6 +1139,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/line-column": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha512-Ktrjk5noGYlHsVnYWh62FLVs4hTb8A3e+vucNZMgPeAOITdshMSgv4cCZQeRDjm7+goqmo6+liZwTXo+U3sVww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^1.0.0",
+        "isobject": "^2.0.0"
       }
     },
     "node_modules/linkify-it": {
@@ -1325,6 +1390,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ohm-js": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.5.0.tgz",
+      "integrity": "sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.1"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -1429,6 +1504,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prr": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "private": true,
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
-    "@quasibit/eleventy-plugin-sitemap": "^2.0.0"
+    "@quasibit/eleventy-plugin-sitemap": "^2.0.0",
+    "@shopify/prettier-plugin-liquid": "^1.10.2",
+    "prettier": "^3.8.1"
   },
   "scripts": {
     "build": "npx @11ty/eleventy",

--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -6,22 +6,19 @@
           <a class="text-decoration-none text-white" rel="noreferrer" href="#">Back to top</a>
         </li>
         <li class="col-md-auto col-6 mb-1 mb-md-0">
-          <a class="text-decoration-none text-white"
-             rel="noreferrer"
-             target="_blank"
-             href="https://dot.ca.gov/privacy-policy">Privacy policy</a>
+          <a class="text-decoration-none text-white" rel="noreferrer" target="_blank" href="https://dot.ca.gov/privacy-policy"
+            >Privacy policy</a
+          >
         </li>
         <li class="col-md-auto col-12 my-1 my-md-0">
-          <a class="text-decoration-none text-white"
-             rel="noreferrer"
-             target="_blank"
-             href="https://www.ca.gov/use/">Conditions of use</a>
+          <a class="text-decoration-none text-white" rel="noreferrer" target="_blank" href="https://www.ca.gov/use/"
+            >Conditions of use</a
+          >
         </li>
         <li class="col-md-auto col-12 my-1 my-md-0">
-          <a class="text-decoration-none text-white"
-             rel="noreferrer"
-             target="_blank"
-             href="https://registertovote.ca.gov/">Register to vote</a>
+          <a class="text-decoration-none text-white" rel="noreferrer" target="_blank" href="https://registertovote.ca.gov/"
+            >Register to vote</a
+          >
         </li>
       </ul>
     </nav>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,22 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    {% include "meta.html" %}
-
-    {% include "styles.html" %}
-
-    {% include "analytics.html" %}
+    {% include "meta.html" %} {% include "styles.html" %} {% include "analytics.html" %}
   </head>
 
   <body>
     {% include "header.html" %}
-    <main class="container">
-      {{ content }}
-    </main>
-    {% include "footer.html" %}
+    <main class="container">{{ content }}</main>
+    {% include "footer.liquid" %}
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-            crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+      crossorigin="anonymous"
+    ></script>
   </body>
 </html>


### PR DESCRIPTION
this PR is a reboot of https://github.com/cal-itp/calitp.org/pull/537 (and a bit of an improvement over https://github.com/cal-itp/mobility-marketplace/pull/824)

on the `11ty` branch right now, pre-commit and VS Code can't agree on how to format liquid code. this PR proposes that we drop the jinja flavored djlint pre-commit step in favor of prettier itself (w/ the shopify plugin enabled).

going forward, to get the formatting we want in VS Code _and_ in pre-commit, we're going to need to update the extensions on more files from `.html` to `.liquid`. it seems ideal to just do it as we go instead of injecting another noisy step 0 commit, but i'm happy to discuss alternatives.

🚧 ~reverting to draft to fix the CI error.~ 🚧 