### PR TITLE
chore: get 11ty loading stylesheets

### DIFF
--- a/.cspell/dev-dictionary.txt
+++ b/.cspell/dev-dictionary.txt
@@ -77,6 +77,8 @@ smallcaps
 smartsymbols
 stylesheet
 superfences
+tbody
+thead
 toc
 tombi
 twemoji

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# this file has custom formatting we don't want prettier to revert
+src/stylesheets/dsdl/tokens.css.liquid

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -2,7 +2,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.setInputDirectory("src");
   eleventyConfig.setLayoutsDirectory("_layouts");
 
-  eleventyConfig.addPassthroughCopy("src/stylesheets/");
+  eleventyConfig.addPassthroughCopy("src/stylesheets/**/*.css");
   eleventyConfig.addWatchTarget("src/stylesheets/");
 
   eleventyConfig.addPassthroughCopy("src/scripts/");

--- a/src/_data/dsdlColors.json
+++ b/src/_data/dsdlColors.json
@@ -1,0 +1,662 @@
+[
+  {
+    "group": "red",
+    "level": 10,
+    "hex": "#fef5f5",
+    "rgb": "254 245 245"
+  },
+  {
+    "group": "red",
+    "level": 20,
+    "hex": "#fbd6d6",
+    "rgb": "251 214 214"
+  },
+  {
+    "group": "red",
+    "level": 30,
+    "hex": "#f9b7b7",
+    "rgb": "249 183 183"
+  },
+  {
+    "group": "red",
+    "level": 40,
+    "hex": "#f37a7b",
+    "rgb": "243 122 123"
+  },
+  {
+    "group": "red",
+    "level": 50,
+    "hex": "#ee4142",
+    "rgb": "238  65  66"
+  },
+  {
+    "group": "red",
+    "level": 60,
+    "hex": "#de0e10",
+    "rgb": "222  14  16"
+  },
+  {
+    "group": "red",
+    "level": 70,
+    "hex": "#980a0b",
+    "rgb": "152  10  11"
+  },
+  {
+    "group": "red",
+    "level": 80,
+    "hex": "#750809",
+    "rgb": "117   8   9"
+  },
+  {
+    "group": "red",
+    "level": 90,
+    "hex": "#540506",
+    "rgb": " 84   5   6"
+  },
+  {
+    "group": "red",
+    "level": 100,
+    "hex": "#300304",
+    "rgb": " 48   3   4"
+  },
+  {
+    "group": "orange",
+    "level": 10,
+    "hex": "#fff4ef",
+    "rgb": "255 244 239"
+  },
+  {
+    "group": "orange",
+    "level": 20,
+    "hex": "#fed6c4",
+    "rgb": "254 214 196"
+  },
+  {
+    "group": "orange",
+    "level": 30,
+    "hex": "#fcb89a",
+    "rgb": "252 184 154"
+  },
+  {
+    "group": "orange",
+    "level": 40,
+    "hex": "#fa7941",
+    "rgb": "250 121  65"
+  },
+  {
+    "group": "orange",
+    "level": 50,
+    "hex": "#e54f0e",
+    "rgb": "229  79  14"
+  },
+  {
+    "group": "orange",
+    "level": 60,
+    "hex": "#c3440c",
+    "rgb": "195  68  12"
+  },
+  {
+    "group": "orange",
+    "level": 70,
+    "hex": "#852e08",
+    "rgb": "133  46   8"
+  },
+  {
+    "group": "orange",
+    "level": 80,
+    "hex": "#662306",
+    "rgb": "102  35   6"
+  },
+  {
+    "group": "orange",
+    "level": 90,
+    "hex": "#471804",
+    "rgb": " 71  24   4"
+  },
+  {
+    "group": "orange",
+    "level": 100,
+    "hex": "#260d02",
+    "rgb": " 38  13   2"
+  },
+  {
+    "group": "yellow",
+    "level": 10,
+    "hex": "#fff6de",
+    "rgb": "255 246 222"
+  },
+  {
+    "group": "yellow",
+    "level": 20,
+    "hex": "#ffda84",
+    "rgb": "255 218 132"
+  },
+  {
+    "group": "yellow",
+    "level": 30,
+    "hex": "#febd28",
+    "rgb": "254 189  40"
+  },
+  {
+    "group": "yellow",
+    "level": 40,
+    "hex": "#ce9411",
+    "rgb": "206 148  17"
+  },
+  {
+    "group": "yellow",
+    "level": 50,
+    "hex": "#a97a0e",
+    "rgb": "169 122  14"
+  },
+  {
+    "group": "yellow",
+    "level": 60,
+    "hex": "#90680c",
+    "rgb": "144 104  12"
+  },
+  {
+    "group": "yellow",
+    "level": 70,
+    "hex": "#614608",
+    "rgb": " 97  70   8"
+  },
+  {
+    "group": "yellow",
+    "level": 80,
+    "hex": "#4a3506",
+    "rgb": " 74  53   6"
+  },
+  {
+    "group": "yellow",
+    "level": 90,
+    "hex": "#332404",
+    "rgb": " 51  36   4"
+  },
+  {
+    "group": "yellow",
+    "level": 100,
+    "hex": "#1b1402",
+    "rgb": " 27  20   2"
+  },
+  {
+    "group": "green",
+    "level": 10,
+    "hex": "#f1f7f5",
+    "rgb": "241 247 245"
+  },
+  {
+    "group": "green",
+    "level": 20,
+    "hex": "#cde3da",
+    "rgb": "205 227 218"
+  },
+  {
+    "group": "green",
+    "level": 30,
+    "hex": "#abd0c0",
+    "rgb": "171 208 192"
+  },
+  {
+    "group": "green",
+    "level": 40,
+    "hex": "#6bab90",
+    "rgb": "107 171 144"
+  },
+  {
+    "group": "green",
+    "level": 50,
+    "hex": "#3b916c",
+    "rgb": " 59 145 108"
+  },
+  {
+    "group": "green",
+    "level": 60,
+    "hex": "#1b7e54",
+    "rgb": " 27 126  84"
+  },
+  {
+    "group": "green",
+    "level": 70,
+    "hex": "#105538",
+    "rgb": " 16  85  56"
+  },
+  {
+    "group": "green",
+    "level": 80,
+    "hex": "#0c412a",
+    "rgb": " 12  65  42"
+  },
+  {
+    "group": "green",
+    "level": 90,
+    "hex": "#092c1d",
+    "rgb": "  9  44  29"
+  },
+  {
+    "group": "green",
+    "level": 100,
+    "hex": "#05170f",
+    "rgb": "  5  23  15"
+  },
+  {
+    "group": "cyan",
+    "level": 10,
+    "hex": "#dff3fe",
+    "rgb": "223 243 254"
+  },
+  {
+    "group": "cyan",
+    "level": 20,
+    "hex": "#bfe4f0",
+    "rgb": "191 228 240"
+  },
+  {
+    "group": "cyan",
+    "level": 30,
+    "hex": "#91d1e5",
+    "rgb": "145 209 229"
+  },
+  {
+    "group": "cyan",
+    "level": 40,
+    "hex": "#38abd0",
+    "rgb": " 56 171 208"
+  },
+  {
+    "group": "cyan",
+    "level": 50,
+    "hex": "#258cad",
+    "rgb": " 37 140 173"
+  },
+  {
+    "group": "cyan",
+    "level": 60,
+    "hex": "#207894",
+    "rgb": " 32 120 148"
+  },
+  {
+    "group": "cyan",
+    "level": 70,
+    "hex": "#155163",
+    "rgb": " 21  81  99"
+  },
+  {
+    "group": "cyan",
+    "level": 80,
+    "hex": "#103d4c",
+    "rgb": " 16  61  76"
+  },
+  {
+    "group": "cyan",
+    "level": 90,
+    "hex": "#0b2b34",
+    "rgb": " 11  43  52"
+  },
+  {
+    "group": "cyan",
+    "level": 100,
+    "hex": "#06161c",
+    "rgb": "  6  22  28"
+  },
+  {
+    "group": "blue",
+    "level": 10,
+    "hex": "#f2f8f9",
+    "rgb": "242 248 249"
+  },
+  {
+    "group": "blue",
+    "level": 20,
+    "hex": "#cbe2e7",
+    "rgb": "203 226 231"
+  },
+  {
+    "group": "blue",
+    "level": 30,
+    "hex": "#82b9c6",
+    "rgb": "130 185 198"
+  },
+  {
+    "group": "blue",
+    "level": 40,
+    "hex": "#6ca7b8",
+    "rgb": "108 167 184"
+  },
+  {
+    "group": "blue",
+    "level": 50,
+    "hex": "#488aa2",
+    "rgb": " 72 138 162"
+  },
+  {
+    "group": "blue",
+    "level": 60,
+    "hex": "#307693",
+    "rgb": " 48 118 147"
+  },
+  {
+    "group": "blue",
+    "level": 70,
+    "hex": "#045b86",
+    "rgb": "  4  91 134"
+  },
+  {
+    "group": "blue",
+    "level": 80,
+    "hex": "#044869",
+    "rgb": "  4  72 105"
+  },
+  {
+    "group": "blue",
+    "level": 90,
+    "hex": "#022a3d",
+    "rgb": "  2  42  61"
+  },
+  {
+    "group": "blue",
+    "level": 100,
+    "hex": "#011621",
+    "rgb": "  1  22  33"
+  },
+  {
+    "group": "purple",
+    "level": 10,
+    "hex": "#f7f7fa",
+    "rgb": "247 247 250"
+  },
+  {
+    "group": "purple",
+    "level": 20,
+    "hex": "#deddea",
+    "rgb": "222 221 234"
+  },
+  {
+    "group": "purple",
+    "level": 30,
+    "hex": "#c7c5db",
+    "rgb": "199 197 219"
+  },
+  {
+    "group": "purple",
+    "level": 40,
+    "hex": "#9e9ac2",
+    "rgb": "158 154 194"
+  },
+  {
+    "group": "purple",
+    "level": 50,
+    "hex": "#817caf",
+    "rgb": "129 124 175"
+  },
+  {
+    "group": "purple",
+    "level": 60,
+    "hex": "#6d68a3",
+    "rgb": "109 104 163"
+  },
+  {
+    "group": "purple",
+    "level": 70,
+    "hex": "#47418b",
+    "rgb": " 71  65 139"
+  },
+  {
+    "group": "purple",
+    "level": 80,
+    "hex": "#332d7e",
+    "rgb": " 51  45 126"
+  },
+  {
+    "group": "purple",
+    "level": 90,
+    "hex": "#211b61",
+    "rgb": " 33  27  97"
+  },
+  {
+    "group": "purple",
+    "level": 100,
+    "hex": "#120f33",
+    "rgb": " 18  15  51"
+  },
+  {
+    "group": "indigo",
+    "level": 10,
+    "hex": "#f7f7ff",
+    "rgb": "247 247 255"
+  },
+  {
+    "group": "indigo",
+    "level": 20,
+    "hex": "#dddbff",
+    "rgb": "221 219 255"
+  },
+  {
+    "group": "indigo",
+    "level": 30,
+    "hex": "#c4c1ff",
+    "rgb": "196 193 255"
+  },
+  {
+    "group": "indigo",
+    "level": 40,
+    "hex": "#9792ff",
+    "rgb": "151 146 255"
+  },
+  {
+    "group": "indigo",
+    "level": 50,
+    "hex": "#756fff",
+    "rgb": "117 111 255"
+  },
+  {
+    "group": "indigo",
+    "level": 60,
+    "hex": "#645ddf",
+    "rgb": "100  93 223"
+  },
+  {
+    "group": "indigo",
+    "level": 70,
+    "hex": "#433f96",
+    "rgb": " 67  63 150"
+  },
+  {
+    "group": "indigo",
+    "level": 80,
+    "hex": "#333072",
+    "rgb": " 51  48 114"
+  },
+  {
+    "group": "indigo",
+    "level": 90,
+    "hex": "#23214f",
+    "rgb": " 35  33  79"
+  },
+  {
+    "group": "indigo",
+    "level": 100,
+    "hex": "#13112a",
+    "rgb": " 19  17  42"
+  },
+  {
+    "group": "pink",
+    "level": 10,
+    "hex": "#fcf4f8",
+    "rgb": "252 244 248"
+  },
+  {
+    "group": "pink",
+    "level": 20,
+    "hex": "#f3d7e5",
+    "rgb": "243 215 229"
+  },
+  {
+    "group": "pink",
+    "level": 30,
+    "hex": "#ebb9d2",
+    "rgb": "235 185 210"
+  },
+  {
+    "group": "pink",
+    "level": 40,
+    "hex": "#db83b0",
+    "rgb": "219 131 176"
+  },
+  {
+    "group": "pink",
+    "level": 50,
+    "hex": "#ce5894",
+    "rgb": "206  88 148"
+  },
+  {
+    "group": "pink",
+    "level": 60,
+    "hex": "#c4367e",
+    "rgb": "196  54 126"
+  },
+  {
+    "group": "pink",
+    "level": 70,
+    "hex": "#901052",
+    "rgb": "144  16  82"
+  },
+  {
+    "group": "pink",
+    "level": 80,
+    "hex": "#6f0c3f",
+    "rgb": "111  12  63"
+  },
+  {
+    "group": "pink",
+    "level": 90,
+    "hex": "#4e082c",
+    "rgb": " 78   8  44"
+  },
+  {
+    "group": "pink",
+    "level": 100,
+    "hex": "#2c0519",
+    "rgb": " 44   5  25"
+  },
+  {
+    "group": "gray",
+    "level": 10,
+    "hex": "#f7f7f7",
+    "rgb": "247 247 247"
+  },
+  {
+    "group": "gray",
+    "level": 20,
+    "hex": "#dedede",
+    "rgb": "222 222 222"
+  },
+  {
+    "group": "gray",
+    "level": 30,
+    "hex": "#c7c7c7",
+    "rgb": "199 199 199"
+  },
+  {
+    "group": "gray",
+    "level": 40,
+    "hex": "#9e9e9e",
+    "rgb": "158 158 158"
+  },
+  {
+    "group": "gray",
+    "level": 50,
+    "hex": "#828282",
+    "rgb": "130 130 130"
+  },
+  {
+    "group": "gray",
+    "level": 60,
+    "hex": "#6e6e6e",
+    "rgb": "110 110 110"
+  },
+  {
+    "group": "gray",
+    "level": 70,
+    "hex": "#4a4a4a",
+    "rgb": " 74  74  74"
+  },
+  {
+    "group": "gray",
+    "level": 80,
+    "hex": "#383838",
+    "rgb": " 56  56  56"
+  },
+  {
+    "group": "gray",
+    "level": 90,
+    "hex": "#262626",
+    "rgb": " 38  38  38"
+  },
+  {
+    "group": "gray",
+    "level": 100,
+    "hex": "#141414",
+    "rgb": " 20  20  20"
+  },
+  {
+    "group": "slate",
+    "level": 10,
+    "hex": "#edf0f4",
+    "rgb": "237 240 244"
+  },
+  {
+    "group": "slate",
+    "level": 20,
+    "hex": "#dadee1",
+    "rgb": "218 222 225"
+  },
+  {
+    "group": "slate",
+    "level": 30,
+    "hex": "#c1c8cc",
+    "rgb": "193 200 204"
+  },
+  {
+    "group": "slate",
+    "level": 40,
+    "hex": "#94a0a8",
+    "rgb": "148 160 168"
+  },
+  {
+    "group": "slate",
+    "level": 50,
+    "hex": "#75848e",
+    "rgb": "117 132 142"
+  },
+  {
+    "group": "slate",
+    "level": 60,
+    "hex": "#62717b",
+    "rgb": " 98 113 123"
+  },
+  {
+    "group": "slate",
+    "level": 70,
+    "hex": "#424c53",
+    "rgb": " 66  76  83"
+  },
+  {
+    "group": "slate",
+    "level": 80,
+    "hex": "#313a3e",
+    "rgb": " 49  58  62"
+  },
+  {
+    "group": "slate",
+    "level": 90,
+    "hex": "#22272b",
+    "rgb": " 34  39  43"
+  },
+  {
+    "group": "slate",
+    "level": 100,
+    "hex": "#121416",
+    "rgb": " 18  20  22"
+  }
+]

--- a/src/_includes/styles.html
+++ b/src/_includes/styles.html
@@ -4,9 +4,11 @@
 <!-- Place favicon.ico in the root directory -->
 
 <link rel="preconnect" href="https://fonts.gstatic.com" />
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous" />
+<link
+  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+  rel="stylesheet"
+  integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+  crossorigin="anonymous"
+/>
 <link rel="stylesheet" href="/stylesheets/main.css" />
-{% if page.stylesheet %}<link rel="stylesheet" href="/stylesheets/{{ page.stylesheet }}" />{% endif %}
+{% if stylesheet %}<link rel="stylesheet" href="/stylesheets/{{ stylesheet }}" />{% endif %}

--- a/src/dsdl.liquid
+++ b/src/dsdl.liquid
@@ -3,12 +3,8 @@ title: DSDL demo
 layout: default
 stylesheet: dsdl-demo.css
 ---
-
-{% comment %} djlint:off {% endcomment %}
-
 <div class="dsdl-demo">
-
-  {% include "clipped-header.html" %}
+  {% include 'clipped-header.html' %}
 
   <div class="row justify-content-center">
     <div class="clipped-header background-calitp-blue col-11 col-md-10 mt-4 mt-md-5 mb-4 py-4 py-md-5 px-4 px-md-0">
@@ -44,28 +40,28 @@ stylesheet: dsdl-demo.css
   <p>These CSS variables take the form <code>--dsdl-{color}-{number}</code>. Example: <code>--dsdl-red-40</code></p>
   <div class="dsdl-colors">
     {% comment %} Start the first color group's list, storing its group name in current_group {% endcomment %}
-    {% assign current_group = site.data.dsdl_colors[0].group %}
+    {% assign current_group = dsdlColors[0].group %}
     <ol>
-      {% for color in site.data.dsdl_colors %}
-        {% comment %} Loop through every color in _data/dsdl_colors.yml {% endcomment %}
-
-        {% if color.group != current_group %} {% comment %} If we have changed groups, start a new list {% endcomment %}
-    </ol>
-    <ol>
+      {% for color in dsdlColors %}
+        {% comment %} Loop through every color in _data/dsdlColors.json {% endcomment %}
+        {% if color.group != current_group %}
+          {% comment %} If we have changed groups, start a new list {% endcomment %}
+          </ol>
+          <ol>
         {% endif %}
-
         {% assign current_group = color.group %}
-
         {% comment %} Output the individual color swatch {% endcomment %}
-        <li style="background: {{ color.hex }};
-                   color: {% if color.level <= 50 %}#000{% else %}#fff{% endif %}">
+        <li
+          style="
+            background: {{ color.hex }};
+            color: {% if color.level <= 50 %}#000{% else %}#fff{% endif %}
+          "
+        >
           {{ color.group }}-{{ color.level }}
           {% if color.level == 100 and color.group == 'slate' %}(black){% endif %}
         </li>
-
       {% endfor %}
-
-    {% comment %} Close the last color group's list {% endcomment %}
+      {% comment %} Close the last color group's list {% endcomment %}
     </ol>
   </div>
 
@@ -76,7 +72,8 @@ stylesheet: dsdl-demo.css
   <h4>Space Grotesk</h4>
 
   <p class="font-heading">
-    Space Grotesk is a proportional sans-serif typeface with modern feeling and strong readability. It has a sense of urbanity and trustworthiness, with strong, clean lines. It is used for headings and display text on Cal-ITP websites.
+    Space Grotesk is a proportional sans-serif typeface with modern feeling and strong readability. It has a sense of urbanity and
+    trustworthiness, with strong, clean lines. It is used for headings and display text on Cal-ITP websites.
   </p>
 
   <a class="font-heading" href="https://fonts.google.com/specimen/Space+Grotesk">See it on Google Fonts</a>
@@ -84,7 +81,11 @@ stylesheet: dsdl-demo.css
   <h4 class="font-body">Noto Sans</h4>
 
   <p>
-    Noto is designed specifically for accessibility and global communication, offering high-quality fonts with various weights and widths in sans, serif, mono, and other styles. This font family supports over 1,000 languages and 150 scripts. It’s a contemporary, aesthetic font with high legibility. It supports scripts of California’s main languages: English, Spanish, Mandarin + Cantonese, Tagalog, Vietnamese, Korean, Armenian, Arabic, Russian, Farsi, Hindi, and Japanese. It is used for body copy on Cal-ITP websites.
+    Noto is designed specifically for accessibility and global communication, offering high-quality fonts with various weights and
+    widths in sans, serif, mono, and other styles. This font family supports over 1,000 languages and 150 scripts. It’s a
+    contemporary, aesthetic font with high legibility. It supports scripts of California’s main languages: English, Spanish,
+    Mandarin + Cantonese, Tagalog, Vietnamese, Korean, Armenian, Arabic, Russian, Farsi, Hindi, and Japanese. It is used for body
+    copy on Cal-ITP websites.
   </p>
 
   <a href="https://fonts.google.com/noto/specimen/Noto+Sans">See it on Google Fonts</a>
@@ -92,11 +93,11 @@ stylesheet: dsdl-demo.css
   <h4 class="text-code">Source Code Pro</h4>
 
   <p class="text-code">
-    Source Code Pro is an open-source monospace typeface designed to work well in user interface and coding environments. It is used on Cal-ITP websites when fixed-width type is appropriate, such as displaying code.
+    Source Code Pro is an open-source monospace typeface designed to work well in user interface and coding environments. It is
+    used on Cal-ITP websites when fixed-width type is appropriate, such as displaying code.
   </p>
 
-  <a class="text-code"
-     href="https://fonts.google.com/specimen/Source+Code+Pro">See it on Google Fonts</a>
+  <a class="text-code" href="https://fonts.google.com/specimen/Source+Code+Pro">See it on Google Fonts</a>
 
   <h3>Core styles</h3>
 
@@ -113,147 +114,161 @@ stylesheet: dsdl-demo.css
     <tbody>
       <tr>
         <th>Large</th>
-        <td><!-- Headline L -->
+        <td>
+          <!-- Headline L -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>40px</dd>
+            <dd>40px</dd>
             <dt>font-weight:</dt>
-              <dd>700</dd>
+            <dd>700</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-headline-l">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Title L -->
+        <td>
+          <!-- Title L -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>32px</dd>
+            <dd>32px</dd>
             <dt>font-weight:</dt>
-              <dd>600</dd>
+            <dd>600</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-title-l">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Subtitle L -->
+        <td>
+          <!-- Subtitle L -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>24px</dd>
+            <dd>24px</dd>
             <dt>font-weight:</dt>
-              <dd>500</dd>
+            <dd>500</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-subtitle-l">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Body L -->
+        <td>
+          <!-- Body L -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>16px</dd>
+            <dd>16px</dd>
             <dt>font-weight:</dt>
-              <dd>400</dd>
+            <dd>400</dd>
             <dt>line-height:</dt>
-              <dd>1.5</dd>
+            <dd>1.5</dd>
           </dl>
           <div class="text-body-l">Amazingly few discotheques provide jukeboxes.</div>
         </td>
       </tr>
       <tr>
         <th>Medium</th>
-        <td><!-- Headline M -->
+        <td>
+          <!-- Headline M -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>32px</dd>
+            <dd>32px</dd>
             <dt>font-weight:</dt>
-              <dd>700</dd>
+            <dd>700</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-headline-m">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Title M -->
+        <td>
+          <!-- Title M -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>24px</dd>
+            <dd>24px</dd>
             <dt>font-weight:</dt>
-              <dd>600</dd>
+            <dd>600</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-title-m">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Subtitle M -->
+        <td>
+          <!-- Subtitle M -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>20px</dd>
+            <dd>20px</dd>
             <dt>font-weight:</dt>
-              <dd>500</dd>
+            <dd>500</dd>
             <dt>line-height:</dt>
-              <dd>1.5</dd>
+            <dd>1.5</dd>
           </dl>
           <div class="text-subtitle-m">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Body M -->
+        <td>
+          <!-- Body M -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>14px</dd>
+            <dd>14px</dd>
             <dt>font-weight:</dt>
-              <dd>400</dd>
+            <dd>400</dd>
             <dt>line-height:</dt>
-              <dd>1.625</dd>
+            <dd>1.625</dd>
           </dl>
           <div class="text-body-m">Amazingly few discotheques provide jukeboxes.</div>
         </td>
       </tr>
       <tr>
         <th>Small</th>
-        <td><!-- Headline S -->
+        <td>
+          <!-- Headline S -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>24px</dd>
+            <dd>24px</dd>
             <dt>font-weight:</dt>
-              <dd>700</dd>
+            <dd>700</dd>
             <dt>line-height:</dt>
-              <dd>1.25</dd>
+            <dd>1.25</dd>
           </dl>
           <div class="text-headline-s">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Title S -->
+        <td>
+          <!-- Title S -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>16px</dd>
+            <dd>16px</dd>
             <dt>font-weight:</dt>
-              <dd>600</dd>
+            <dd>600</dd>
             <dt>line-height:</dt>
-              <dd>1.5</dd>
+            <dd>1.5</dd>
           </dl>
           <div class="text-title-s">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Subtitle S -->
+        <td>
+          <!-- Subtitle S -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>16px</dd>
+            <dd>16px</dd>
             <dt>font-weight:</dt>
-              <dd>500</dd>
+            <dd>500</dd>
             <dt>line-height:</dt>
-              <dd>1.5</dd>
+            <dd>1.5</dd>
           </dl>
           <div class="text-subtitle-s">Amazingly few discotheques provide jukeboxes.</div>
         </td>
-        <td><!-- Body S -->
+        <td>
+          <!-- Body S -->
           <dl class="dsdl-type-specs">
             <dt>font-size:</dt>
-              <dd>12px</dd>
+            <dd>12px</dd>
             <dt>font-weight:</dt>
-              <dd>400</dd>
+            <dd>400</dd>
             <dt>line-height:</dt>
-              <dd>1.625</dd>
+            <dd>1.625</dd>
           </dl>
           <div class="text-body-s">Amazingly few discotheques provide jukeboxes.</div>
         </td>
       </tr>
     </tbody>
-    <caption class="visually-hidden">Core font style matrix</caption>
+    <caption class="visually-hidden">
+      Core font style matrix
+    </caption>
   </table>
 
   <ul class="dsdl-extra-type-styles">
@@ -261,11 +276,11 @@ stylesheet: dsdl-demo.css
       <h4>Display</h4>
       <dl class="dsdl-type-specs">
         <dt>font-size:</dt>
-          <dd>64px</dd>
+        <dd>64px</dd>
         <dt>font-weight:</dt>
-          <dd>600</dd>
+        <dd>600</dd>
         <dt>line-height:</dt>
-          <dd>1.125</dd>
+        <dd>1.125</dd>
       </dl>
       <div class="text-display">Amazingly few discotheques provide jukeboxes.</div>
     </li>
@@ -273,13 +288,13 @@ stylesheet: dsdl-demo.css
       <h4>Small caps</h4>
       <dl class="dsdl-type-specs">
         <dt>font-size:</dt>
-          <dd>12px</dd>
+        <dd>12px</dd>
         <dt>font-weight:</dt>
-          <dd>400</dd>
+        <dd>400</dd>
         <dt>line-height:</dt>
-          <dd>1.625</dd>
+        <dd>1.625</dd>
         <dt>text-transform:</dt>
-          <dd>uppercase</dd>
+        <dd>uppercase</dd>
       </dl>
       <div class="text-small-caps">Amazingly few discotheques provide jukeboxes.</div>
     </li>
@@ -287,11 +302,11 @@ stylesheet: dsdl-demo.css
       <h4>Caption</h4>
       <dl class="dsdl-type-specs">
         <dt>font-size:</dt>
-          <dd>12px</dd>
+        <dd>12px</dd>
         <dt>font-weight:</dt>
-          <dd>400</dd>
+        <dd>400</dd>
         <dt>line-height:</dt>
-          <dd>1.625</dd>
+        <dd>1.625</dd>
       </dl>
       <div class="text-caption">Amazingly few discotheques provide jukeboxes.</div>
     </li>
@@ -299,11 +314,11 @@ stylesheet: dsdl-demo.css
       <h4>Footnote</h4>
       <dl class="dsdl-type-specs">
         <dt>font-size:</dt>
-          <dd>10px</dd>
+        <dd>10px</dd>
         <dt>font-weight:</dt>
-          <dd>400</dd>
+        <dd>400</dd>
         <dt>line-height:</dt>
-          <dd>1.625</dd>
+        <dd>1.625</dd>
       </dl>
       <div class="text-footnote">Amazingly few discotheques provide jukeboxes.</div>
     </li>
@@ -311,11 +326,11 @@ stylesheet: dsdl-demo.css
       <h4>Code</h4>
       <dl class="dsdl-type-specs">
         <dt>font-size:</dt>
-          <dd>16px</dd>
+        <dd>16px</dd>
         <dt>font-weight:</dt>
-          <dd>400</dd>
+        <dd>400</dd>
         <dt>line-height:</dt>
-          <dd>1.625</dd>
+        <dd>1.625</dd>
       </dl>
       <div class="text-code">Amazingly few discotheques provide jukeboxes.</div>
     </li>
@@ -335,7 +350,7 @@ stylesheet: dsdl-demo.css
     <tbody>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-05);">
+          <div class="spacing-sample" style="height: var(--spacing-05)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 05 (half)</span>
           </div>
         </td>
@@ -345,7 +360,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-1);">
+          <div class="spacing-sample" style="height: var(--spacing-1)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 1</span>
           </div>
         </td>
@@ -355,7 +370,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-2);">
+          <div class="spacing-sample" style="height: var(--spacing-2)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 2</span>
           </div>
         </td>
@@ -365,7 +380,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-2-05);">
+          <div class="spacing-sample" style="height: var(--spacing-2-05)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 2-05 (two and a half)</span>
           </div>
         </td>
@@ -375,7 +390,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-3);">
+          <div class="spacing-sample" style="height: var(--spacing-3)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 3</span>
           </div>
         </td>
@@ -385,7 +400,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-4);">
+          <div class="spacing-sample" style="height: var(--spacing-4)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 4</span>
           </div>
         </td>
@@ -395,7 +410,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-5);">
+          <div class="spacing-sample" style="height: var(--spacing-5)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 5</span>
           </div>
         </td>
@@ -405,7 +420,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-6);">
+          <div class="spacing-sample" style="height: var(--spacing-6)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 6</span>
           </div>
         </td>
@@ -415,7 +430,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-7);">
+          <div class="spacing-sample" style="height: var(--spacing-7)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 7</span>
           </div>
         </td>
@@ -425,7 +440,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-8);">
+          <div class="spacing-sample" style="height: var(--spacing-8)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 8</span>
           </div>
         </td>
@@ -435,7 +450,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-9);">
+          <div class="spacing-sample" style="height: var(--spacing-9)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 9</span>
           </div>
         </td>
@@ -445,7 +460,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-10);">
+          <div class="spacing-sample" style="height: var(--spacing-10)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 10</span>
           </div>
         </td>
@@ -455,7 +470,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-15);">
+          <div class="spacing-sample" style="height: var(--spacing-15)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 15</span>
           </div>
         </td>
@@ -465,7 +480,7 @@ stylesheet: dsdl-demo.css
       </tr>
       <tr>
         <td>
-          <div class="spacing-sample" style="height: var(--spacing-20);">
+          <div class="spacing-sample" style="height: var(--spacing-20)">
             <span class="visually-hidden">A box illustrating the size of something using spacing 20</span>
           </div>
         </td>
@@ -474,9 +489,10 @@ stylesheet: dsdl-demo.css
         <td>10rem</td>
       </tr>
     </tbody>
-    <caption class="visually-hidden">Chart of our spacing variables with visual reference</caption>
+    <caption class="visually-hidden">
+      Chart of our spacing variables with visual reference
+    </caption>
   </table>
 
   <p>Note: For lines we want to be exactly 1 logical pixel without scaling, we use a <code>1px</code> value directly.</p>
-
 </div>

--- a/src/stylesheets/dsdl/tokens.css.liquid
+++ b/src/stylesheets/dsdl/tokens.css.liquid
@@ -1,5 +1,5 @@
 ---
-# Empty front matter to enable Liquid processing
+permalink: /stylesheets/dsdl/tokens.css
 ---
 
 /*
@@ -48,10 +48,12 @@
 /* COLORS */
 
 :root {
-  {% for color in site.data.dsdl_colors -%}
+  {% for color in dsdlColors -%}
   --dsdl-{{ color.group }}-{{ color.level }}: {{ color.hex }};
   {% endfor %}
+}
 
+:root {
   --calitp-brand-blue:   var(--dsdl-blue-70);    /* #045b86 */
   --calitp-brand-cyan:   var(--dsdl-cyan-40);    /* #38abd0 */
   --calitp-brand-yellow: var(--dsdl-yellow-30);  /* #febd28 */


### PR DESCRIPTION
Part of #587

just a few small tweaks to fix the busted CSS.

the crux of the issue is that 11ty didn't recognize src/stylesheets/dsdl/tokens.css as a liquid template automatically.

<img width="759" height="777" alt="Screenshot 2026-04-03 at 2 41 34 PM" src="https://github.com/user-attachments/assets/0fd7c695-b28b-4bb7-a6d9-f025bad2ba71" />
