### PR TITLE
fix: make footer sticky on /customer-stories

### DIFF
--- a/src/_includes/footer.liquid
+++ b/src/_includes/footer.liquid
@@ -1,4 +1,4 @@
-<section class="{{ page.footer-class }} bg-dark navbar d-print-none">
+<section class="{{ footer-class }} bg-dark navbar d-print-none">
   <footer class="container">
     <nav class="col-12">
       <ul class="list-unstyled row row-column gap-md-4 my-3 my-md-0">


### PR DESCRIPTION
part of #587

right now its borked when you scroll to the bottom of [/customer-stories](https://11ty--cal-itp-website.netlify.app/customer-stories/)

<img width="1270" height="852" alt="Screenshot 2026-04-14 at 10 03 28 AM" src="https://github.com/user-attachments/assets/3f50d1fd-9889-43cf-9472-e23bd2509b19" />