### PR TITLE
chore: add generator meta tag

### DIFF
--- a/src/_includes/meta.liquid
+++ b/src/_includes/meta.liquid
@@ -22,6 +22,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="generator" content="{{ eleventy.generator }}">
 
 {% comment %}
   TODO: figure out 11ty equivalent to seo tag


### PR DESCRIPTION
adds a purely optional tag that helps crawlers inventory just how popular 11ty is on the web. Jekyll injects an equivalent tag automatically:

```html
<meta name="generator" content="Jekyll v4.4.1">
```

11ty's philosophical stance is that it should _never_ inject markup of its own.

ref: https://www.11ty.dev/docs/data-eleventy-supplied/#use-with-meta-namegenerator