### PR TITLE
fix: add custom 'link' shortCode

### DIFF
--- a/.cspell/dev-dictionary.txt
+++ b/.cspell/dev-dictionary.txt
@@ -47,6 +47,7 @@ jinja
 Kegan
 keyserver
 linenums
+liquidjs
 Machiko
 Maher
 markdownextradata

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -11,16 +11,27 @@ export default async function (eleventyConfig) {
   // Keeps the same directory structure.
   eleventyConfig.addPassthroughCopy("src/favicon.ico");
   eleventyConfig.addPassthroughCopy("src/robots.txt");
+  eleventyConfig.addPassthroughCopy("src/assets/");
   eleventyConfig.addPassthroughCopy("**/*.jpg");
   eleventyConfig.addPassthroughCopy("**/*.png");
   eleventyConfig.addPassthroughCopy("**/*.svg");
-
-  eleventyConfig.addPassthroughCopy("src/assets/");
 
   // Define a custom collection for grouping resources by category.
   eleventyConfig.addCollection("resourcesByCategory", (collectionApi) => {
     const resources = collectionApi.getFilteredByTag("resources");
     const groupedByCategory = Object.groupBy(resources, (resource) => resource.data.category);
     return Object.entries(groupedByCategory).sort(); // order by category name in ascending order
+  });
+
+  // mimics jekyll's built-in link tag
+  eleventyConfig.addShortcode("link", function (filePath) {
+    // this syntax is liquidjs specific https://liquidjs.com/api/classes/Context.html#environments
+    const all = this.ctx.environments.collections.all;
+    const found = all.find((page) => page.inputPath.endsWith(filePath));
+
+    // if no page in the 'all' collection matches the input path, fail hard and fast
+    if (!found) throw new Error(`Could not find file ${filePath}`);
+
+    return found.url;
   });
 }

--- a/src/press/cal-itp-coast-rta-msa.md
+++ b/src/press/cal-itp-coast-rta-msa.md
@@ -95,15 +95,10 @@ For more information about this project, Cal-ITP’s technical support, or Calif
 
 ### Cal-ITP
 
-{% comment %}
-TODO: what is the equivalent link syntax in 11ty?
-{% link _press/cal-itp-benefits-launch.md %}
-{% endcomment %}
-
 The California Integrated Travel Project (Cal-ITP) was established by the California State Transportation Agency (CalSTA) and
 California Department of Transportation (Caltrans) to both improve and encourage the use of multimodal travel throughout
 California—by enabling contactless open-loop payments, standardizing information for easy multimodal trip planning, and
-automating customer discounts ([Cal-ITP Benefits](placeholder)). Over the past year, Cal-ITP
+automating customer discounts ([Cal-ITP Benefits]({% link "press/cal-itp-benefits-launch.md" %})). Over the past year, Cal-ITP
 successfully led contactless open-loop contactless payment implementations in California on Monterey-Salinas and Santa Barbara
 buses; Sacramento light rail; on-demand van ride service in San Diego; and LAX’s FlyAway bus, which connects airport passengers
 to commuter rail.


### PR DESCRIPTION
part of #587

this PR wires up a bespoke version of the [link tag built into Jekyll](https://jekyllrb.com/docs/liquid/tags/#link).

with this in place, the entire build will fail if/when the raw markdown file can no longer be found.

## Steps to test
1. load https://deploy-preview-611--cal-itp-website.netlify.app/press/cal-itp-coast-rta-msa/
1. verify 'Cal-ITP Benefits' link resolves

prior art (nunjucks only): https://www.npmjs.com/package/eleventy-plugin-link_to