### PR TITLE
fix: get markdown footnotes rendering correctly

### DIFF
--- a/.cspell/dev-dictionary.txt
+++ b/.cspell/dev-dictionary.txt
@@ -47,6 +47,7 @@ jinja
 Kegan
 keyserver
 linenums
+linkify
 liquidjs
 Machiko
 Maher

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,13 @@
+import markdownIt from "markdown-it";
+import markdownItFootnote from "markdown-it-footnote";
+
 export default async function (eleventyConfig) {
+  // this customization opts us into a markdown parsing feature that parses and
+  // formats footnotes in a div of their own at the bottom of the page
+  // Jekyll provides this functionality OOTB
+  const mdOptions = { html: true, linkify: true };
+  eleventyConfig.setLibrary("md", markdownIt(mdOptions).use(markdownItFootnote));
+
   eleventyConfig.setInputDirectory("src");
   eleventyConfig.setLayoutsDirectory("_layouts");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@11ty/eleventy": "^3.0.0",
         "@quasibit/eleventy-plugin-sitemap": "^2.0.0",
         "@shopify/prettier-plugin-liquid": "^1.10.2",
+        "markdown-it": "^14.1.1",
+        "markdown-it-footnote": "^4.0.0",
         "prettier": "^3.8.1"
       }
     },
@@ -1217,6 +1219,13 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@11ty/eleventy": "^3.0.0",
     "@quasibit/eleventy-plugin-sitemap": "^2.0.0",
     "@shopify/prettier-plugin-liquid": "^1.10.2",
+    "markdown-it": "^14.1.1",
+    "markdown-it-footnote": "^4.0.0",
     "prettier": "^3.8.1"
   },
   "scripts": {


### PR DESCRIPTION
fix for the issue reported in https://github.com/cal-itp/calitp.org/pull/608#pullrequestreview-4109329326:

* gets the footnotes on [this page](https://deploy-preview-612--cal-itp-website.netlify.app/resources/fact-sheet-improving-financial-access-through-secured-credit-cards/) rendering correctly
* Doesn't introduce any other visual regressions in markdown-based pages