### PR TITLE
chore: configure 11ty sitemap plugin

### DIFF
--- a/.cspell/dev-dictionary.txt
+++ b/.cspell/dev-dictionary.txt
@@ -41,6 +41,7 @@ Grotesk
 gtag
 gtfs
 headerlink
+hubspot
 inlinehilite
 jekyll
 jinja

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,7 +1,12 @@
+import sitemap from "@quasibit/eleventy-plugin-sitemap";
 import markdownIt from "markdown-it";
 import markdownItFootnote from "markdown-it-footnote";
 
+import site from "./src/_data/site.js";
+
 export default async function (eleventyConfig) {
+  eleventyConfig.addPlugin(sitemap, { sitemap: { hostname: site.url } });
+
   // this customization opts us into a markdown parsing feature that parses and
   // formats footnotes in a div of their own at the bottom of the page
   // Jekyll provides this functionality OOTB

--- a/src/404.html
+++ b/src/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 permalink: /404.html
+eleventyExcludeFromCollections: true
 ---
 
 <article>

--- a/src/_includes/meta.liquid
+++ b/src/_includes/meta.liquid
@@ -1,22 +1,22 @@
-{%- if page.title -%}
-  {%- assign page_title = page.title -%}
-  {%- assign title = page.title | append: ' - ' | append: site.title -%}
+{%- if title -%}
+  {%- assign page_title = title -%}
+  {%- assign title = title | append: ' - ' | append: site.title -%}
 {%- else -%}
   {%- assign page_title = site.title -%}
   {%- assign title = site.title -%}
 {%- endif -%}
 
-{%- if page.lead -%}
-  {%- assign description = page.lead -%}
-{%- elsif page.intro -%}
-  {%- assign description = page.intro -%}
-{%- elsif page.description -%}
-  {%- assign description = page.description -%}
+{%- if lead -%}
+  {%- assign description = lead -%}
+{%- elsif intro -%}
+  {%- assign description = intro -%}
+{%- elsif description -%}
+  {%- assign description = description -%}
 {%- else -%}
-  {%- assign description = site.description -%}
+  {%- assign description = description -%}
 {%- endif -%}
 {%- assign description = description | normalize_whitespace -%}
-{%- assign is_article = page.date and page.tags -%}
+{%- assign is_article = date and tags -%}
 
 <meta charset="utf-8">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -31,12 +31,12 @@
 {% endcomment %}
 
 {%- if is_article -%}
-  {%- for tag in page.tags -%}
+  {%- for tag in tags -%}
     <meta property="article:tag" content="{{ tag }}">
   {%- endfor -%}
   <meta
     property="article:published_time"
-    content="{{ page.date | date: "%FT%T%z" }}"
+    content="{{ date | date: "%FT%T%z" }}"
   >
 {%- endif -%}
 
@@ -48,6 +48,6 @@
 <meta name="twitter:domain" content="{{ site.domain }}">
 
 {% comment %} <link rel="canonical" href="{{ page.url | absolute_url }}" /> {% endcomment %}
-{% if page.asset or page.external -%}
+{% if asset or external -%}
   <meta name="robots" content="noindex">
 {%- endif -%}

--- a/src/_layouts/redirect.liquid
+++ b/src/_layouts/redirect.liquid
@@ -1,21 +1,19 @@
----
----
 <!doctype html>
 <html>
   <head>
     {% include 'meta' %}
     {% include 'styles.html' %}
     {% include 'analytics.html' %}
-    <link rel="canonical" href="{{ page.redirect_to }}">
+    <link rel="canonical" href="{{ redirect_to }}">
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
-    <meta http-equiv="refresh" content="0;url={{ page.redirect_to }}">
+    <meta http-equiv="refresh" content="0;url={{ redirect_to }}">
   </head>
 
   <body>
     {% include 'header' %}
     <article>
       <section id="deck">
-        {% include 'script_redirect', location: page.redirect_to %}
+        {% include 'script_redirect', location: redirect_to %}
       </section>
     </article>
   </body>

--- a/src/dsdl.liquid
+++ b/src/dsdl.liquid
@@ -2,6 +2,7 @@
 title: DSDL demo
 layout: default
 stylesheet: dsdl-demo.css
+eleventyExcludeFromCollections: true
 ---
 <div class="dsdl-demo">
   {% include 'clipped-header.html' %}

--- a/src/links.html
+++ b/src/links.html
@@ -1,4 +1,5 @@
 ---
 layout: redirect
 redirect_to: "https://share.hsforms.com/1RORrSA2FTQuiN1xEpxMv1A3aanu"
+eleventyExcludeFromCollections: true
 ---

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -2,4 +2,5 @@
 
 # Allow crawling of all content
 User-agent: *
-Disallow: /stylesheet.html
+
+Sitemap: https://www.calitp.org/sitemap.xml

--- a/src/sitemap.xml.liquid
+++ b/src/sitemap.xml.liquid
@@ -1,0 +1,6 @@
+---
+permalink: /sitemap.xml
+layout: null
+eleventyExcludeFromCollections: true
+---
+{% sitemap collections.all %}

--- a/src/stylesheets/dsdl/tokens.css.liquid
+++ b/src/stylesheets/dsdl/tokens.css.liquid
@@ -1,5 +1,6 @@
 ---
 permalink: /stylesheets/dsdl/tokens.css
+eleventyExcludeFromCollections: true
 ---
 
 /*


### PR DESCRIPTION
resolves #588.

* wires up an 11ty plugin to generate /sitemap.xml
* omits /404.html and other pages that we don't want to publicize
* fixes a few bugs related to outdated attempts to access custom front-matter props associated with individual pages that i caught out along the way. (CIL for more info)