### PR TITLE
fix: ensure inline links do not need to redirect

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -4,15 +4,15 @@ export default {
     header: [
       {
         name: "Customer stories",
-        url: "/customer-stories",
+        url: "/customer-stories/",
       },
       {
         name: "Resources",
-        url: "/resources",
+        url: "/resources/",
       },
       {
         name: "Press",
-        url: "/press",
+        url: "/press/",
       },
       {
         name: "Reach out",

--- a/src/_includes/initiatives.liquid
+++ b/src/_includes/initiatives.liquid
@@ -132,7 +132,7 @@
                 {% endif %}
               {% endfor %}
             </div>
-            <a class="text-white fw-bold" href="/resources">See all</a>
+            <a class="text-white fw-bold" href="/resources/">See all</a>
           </div>
         </div>
       </div>

--- a/src/_layouts/press.liquid
+++ b/src/_layouts/press.liquid
@@ -16,7 +16,7 @@ layout: default
       <article class="press-release pb-5 mb-5">
         <a
           class="fw-bold d-block text-decoration-none mb-2 pt-3 mt-5"
-          href="/press"
+          href="/press/"
           >Press</a
         >
         <h1 class="h2">{{ heading }}</h1>

--- a/src/_layouts/resource.liquid
+++ b/src/_layouts/resource.liquid
@@ -15,7 +15,7 @@ layout: default
 <div class="row justify-content-center">
   <div class="col-lg-8 col-md-8">
     <article class="press-release pb-5 mb-5">
-      <a class="d-block text-decoration-none mb-2 pt-3 mt-5" href="/resources">Resource</a>
+      <a class="d-block text-decoration-none mb-2 pt-3 mt-5" href="/resources/">Resource</a>
       <h1 class="h2">{{ title }}</h1>
       <hr>
       <p>{{ date }}</p>


### PR DESCRIPTION
while working on #615 i noticed that the links in the header (and a few others) result in a 301 redirect. they're harmless, but they're still worth fixing.

<img width="952" height="196" alt="Screenshot 2026-04-27 at 4 29 29 PM" src="https://github.com/user-attachments/assets/55da8f5c-13b7-4d84-b232-bdb94d3526a0" />