### PR TITLE
Chore: update Auto-PR Resources for 11ty

### DIFF
--- a/.github/scripts/resource-template.py
+++ b/.github/scripts/resource-template.py
@@ -121,7 +121,7 @@ def build_filename(prefix, title):
   return f'{filename}.md'
 
 def create_resource(filename, content):
-  with open(f'src/_resources/{filename}', 'w') as file:
+  with open(f'src/resources/{filename}', 'w') as file:
     file.write(content)
 
 def main():

--- a/.github/workflows/resource-template.yml
+++ b/.github/workflows/resource-template.yml
@@ -64,6 +64,6 @@ jobs:
             review the changes and merge when ready.
 
             Closes #${{ steps.workflow_state.outputs.issue_number }}
-          add-paths: "src/_resources/"
+          add-paths: "src/resources/"
           commit-message: "feat: start resource for req #${{ steps.workflow_state.outputs.issue_number }}"
           branch: "chore/resource-${{ steps.workflow_state.outputs.issue_number }}"


### PR DESCRIPTION
Closes #621 

Fortunately the frontmatter for our resources stayed the same across Jekyll and 11ty, which is of note because the workflow [generates frontmatter](https://github.com/cal-itp/calitp.org/blob/f6b5b71147caaca621d438a564f79d780f6582e0/.github/scripts/resource-template.py#L182-L189) for the requested resource upload, so the only thing to update was the directory name.