### PR TITLE
fix: reference 'external' front-matter for press items correctly

### DIFF
--- a/src/_includes/article.liquid
+++ b/src/_includes/article.liquid
@@ -9,7 +9,7 @@
   {% endif %}
 {% else %}
   {% assign url = item.url %}
-  {% if item.external %}
+  {% if item.data.external %}
     {% assign url = item.data.external %}
   {% endif %}
 {% endif %}


### PR DESCRIPTION
closes #629