### PR TITLE
ci: ask dependabot to scan for npm dependency updates instead of looking for gemfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of Gemfile
+  - package-ecosystem: "npm"
+    # Look for `package*.json` files in the `root` directory
+    directory: "/"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
closes #595 

analogous to https://github.com/cal-itp/mobility-marketplace/pull/852