### PR TITLE
fix: use YML block scalar to collapse newlines in leads/intros

### DIFF
--- a/src/press/cal-itp-announces-ods.md
+++ b/src/press/cal-itp-announces-ods.md
@@ -2,7 +2,7 @@
 date: "2022-06-02T17:00:00"
 title: ODS—New open data standard helps improve transit agency operations
 heading: ODS—New open data standard helps improve transit agency operations
-intro: |-
+intro: >-
   Caltrans’ California Integrated Travel Project (Cal-ITP) today launched a new open data standard to capture and integrate
   more information impacting transit agency operations. The Operational Data Standard (ODS) leverages the existing GTFS
   (General Transit Feed Specification) standard used by transit agencies and riders all over the world for transit service

--- a/src/press/cal-itp-benefits-launch.md
+++ b/src/press/cal-itp-benefits-launch.md
@@ -1,13 +1,13 @@
 ---
 date: "2022-09-21T17:00:00"
 title: Cal-ITP Benefits is first web tool to enable transit riders to verify identity and benefit eligibility, link fare discounts to bank cards
-heading: |-
+heading: >-
   State of California launches Cal-ITP Benefits, the first online tool for transit riders to verify their identity and benefit
   eligibility and link fare discounts to debit and credit cards
-lead: |-
+lead: >-
   California is one of the first states to integrate the federal government’s secure Login.gov sign-in service, enabling older
   adults to tap to pay a discounted bus fare at participating transit agencies
-intro: |-
+intro: >-
   The debut of a new web application called <a href="https://benefits.calitp.org/" target="_blank">Cal-ITP Benefits</a> allows
   transit riders to quickly and securely verify their eligibility online for discounted fares and link that discount benefit to
   a contactless debit or credit card to automatically receive reduced fares whenever they tap to pay with the card.

--- a/src/press/cal-itp-coast-rta-msa.md
+++ b/src/press/cal-itp-coast-rta-msa.md
@@ -1,12 +1,12 @@
 ---
 date: "2022-10-14T17:00:00"
 title: South Carolina transit agency taps California’s contracts for competitively priced contactless fare payment system
-heading: |-
+heading: >-
   South Carolina transit agency taps California’s contracts for competitively priced contactless fare payment system
-lead: |-
+lead: >-
   Coast RTA leverages California’s approved vendors for a modern fare system that accepts riders’ mobile wallets and bank
   cards—including the free Cash App Card, a Visa debit card for all riders that provides unbanked riders with a financial account
-intro: |-
+intro: >-
   With its rollout of contactless payment acceptance devices aboard its bus fleet, South Carolina’s Coast RTA is the first
   public transit agency from another state to use the State of California’s competitively priced contracts to purchase and
   install the hardware and software services needed for accepting customers’ debit and credit cards and mobile wallets for fare

--- a/src/press/cal-itp-dgs-rfp-msa.md
+++ b/src/press/cal-itp-dgs-rfp-msa.md
@@ -1,9 +1,9 @@
 ---
 date: "2022-03-09T17:00:00"
 title: State of California’s purchasing agreements allow public transit agencies across U.S. to skip procurement and quickly modernize fare collection systems
-heading: |-
+heading: >-
   State of California’s purchasing agreements allow public transit agencies across U.S. to skip procurement and quickly modernize fare collection systems
-intro: |-
+intro: >-
   California is making it easier and more affordable for public transportation providers anywhere in the U.S. to acquire the tools to allow riders a convenient option to pay their fare using a contactless credit/debit/prepaid card or mobile wallet on a smart device.
 tags:
   - Contactless Payments

--- a/src/press/cal-itp-expands-contactless-payment-options.md
+++ b/src/press/cal-itp-expands-contactless-payment-options.md
@@ -1,9 +1,9 @@
 ---
 date: "2025-10-31T17:00:00"
 title: "Cal-ITP Expands Contactless Payment Options: Transit Riders Can Now Pay with Discover® Network"
-heading: |-
+heading: >-
   Cal-ITP Expands Contactless Payment Options: Transit Riders Can Now Pay with Discover® Network
-intro: |-
+intro: >-
   The California Integrated Travel Project (Cal-ITP) is excited to announce that transit agencies partnering with Cal-ITP can accept credit card payments and process fares using Discover® Cards. This marks a major milestone that expands the accessibility of convenient, contactless transit payments for riders across California.
 tags:
   - Contactless Payments

--- a/src/press/cal-itp-first-net-cellular-plans.md
+++ b/src/press/cal-itp-first-net-cellular-plans.md
@@ -1,11 +1,11 @@
 ---
 date: "2022-11-03T17:00:00"
 title: Discounted cellular data plans now available for U.S. public transportation providers via California Mobility Marketplace
-heading: |-
+heading: >-
   Discounted cellular data plans now available for U.S. public transportation providers via California Mobility Marketplace
-lead: |-
+lead: >-
   Caltrans’ Cal-ITP negotiates below-market rates for wider coverage areas and offers grant-based subsidies to state transit agencies via California Mobility Marketplace
-intro: |-
+intro: >-
   Whether accepting customers’ mobile wallets for fare payments or sharing the live location of a bus, public transportation providers are using more technology and internet-connected devices to improve the rider experience. To match this need for cellular data, Caltrans’ California Integrated Travel Project (Cal-ITP) negotiated below-market rates for data-only plans that can be tapped by transit agencies—in California and throughout the U.S. California transit agencies can also access even lower payments through state subsidies by reaching out to Cal-ITP for technical support.
 tags:
   - Data Plans

--- a/src/press/cal-itp-partners-celebrate-major-milestone-implementation-ods.md
+++ b/src/press/cal-itp-partners-celebrate-major-milestone-implementation-ods.md
@@ -2,7 +2,7 @@
 date: "2023-08-22T09:00:00"
 title: Cal-ITP and partners celebrate major milestones in implementation of Operational Data Standard (ODS) for transit
 heading: Cal-ITP and partners celebrate major milestones in implementation of Operational Data Standard (ODS) for transit
-intro: |-
+intro: >-
   The California Integrated Travel Project (Cal-ITP) today announced significant progress in implementing the Operational Data
   Standard (ODS) for transit agencies. In a major milestone for the project, the first vendor-to-vendor integrations powered by
   ODS have been officially launched. Five companies—EQUANS, Remix (owned by Via), Schedule Masters, Swiftly, and GIRO—now are

--- a/src/press/four-northern-california-transit-agencies-join-forces-to-buy-contactless-open-loop-fare-payment-systems-off-of-californias-purchasing-agreements.md
+++ b/src/press/four-northern-california-transit-agencies-join-forces-to-buy-contactless-open-loop-fare-payment-systems-off-of-californias-purchasing-agreements.md
@@ -2,9 +2,9 @@
 date: "2023-08-18T00:00:00"
 title: Four Northern California transit agencies join forces to buy contactless open-loop fare payment systems off of California’s purchasing agreements
 heading: Four Northern California transit agencies join forces to buy contactless open-loop fare payment systems off of California’s purchasing agreements
-lead: |-
+lead: >-
   Humboldt Transit Authority, Lake Transit Authority, Mendocino Transit Authority, and Redwood Coast Transit Authority install a modern fare system that accepts riders’ bank cards and mobile wallets
-intro: |-
+intro: >-
   Transit riders in four counties north of the San Francisco Bay Area can now tap to ride the bus on four public transit agencies—and seamlessly transfer between the agencies’ dial-a-ride vehicles or local and regional lines at shared bus stops—without stopping to download any apps, purchase or reload multiple agency fare cards, or juggle exact change.
 tags:
   - Contactless Payments

--- a/src/press/valleycan-preloaded-reloadable-ev-charging.md
+++ b/src/press/valleycan-preloaded-reloadable-ev-charging.md
@@ -1,9 +1,9 @@
 ---
 date: "2022-08-01T17:00:00"
 title: Valley CAN and the State of California issue preloaded, reloadable contactless debit cards for low-income EV owners to use at any charging station
-heading: |-
+heading: >-
   Valley CAN and the State of California issue preloaded, reloadable contactless debit cards for low-income EV owners to use at any charging station
-intro: |-
+intro: >-
   One hundred low-income electric vehicle (EV) owners in the San Joaquin Valley are receiving reloadable contactless debit cards to use at EV charging stations as part of a demonstration project launched today by Valley Clean Air Now (Valley CAN) and the State of California.
 tags:
   - Contactless Payments

--- a/src/resources/case-study-cash-app.md
+++ b/src/resources/case-study-cash-app.md
@@ -1,6 +1,6 @@
 ---
 date: "2022-11-01T17:00:00"
-title: |-
+title: >-
   Case study: Instead of using cash, Monterey and Sacramento riders are choosing to tap the free Cash App Visa debit card
 asset: Cal-ITP.CashApp.CaseStudy.pdf
 last_modified_at: 2025-11-03T08:00:00-08:00

--- a/src/resources/case-study-contactless-fare-payments.md
+++ b/src/resources/case-study-contactless-fare-payments.md
@@ -1,6 +1,6 @@
 ---
 date: "2022-09-01T17:00:00"
-title: |-
+title: >-
   Case study: Payments Data Dashboard enables transit agencies to visualize their contactless payments data
 asset: Cal-ITP.Contactless.Payments.Data.CaseStudy.2022.pdf
 last_modified_at: 2025-11-03T08:00:00-08:00

--- a/src/resources/case-study-universal-equity-zero-emission-charging-card.md
+++ b/src/resources/case-study-universal-equity-zero-emission-charging-card.md
@@ -1,6 +1,6 @@
 ---
 date: "2023-09-30T17:00:00"
-title: |-
+title: >-
   Universal Equity Zero Emission Vehicle Charging Card: Project Demonstration Report
 asset: Cal-ITP.Universal.Equity.Zero.Emission.Vehicle.Charging.Card.Report.pdf
 last_modified_at: 2025-11-03T08:00:00-08:00

--- a/src/resources/case-study-zeb-market-sounding-report.md
+++ b/src/resources/case-study-zeb-market-sounding-report.md
@@ -1,6 +1,6 @@
 ---
 date: "2024-04-16T17:00:00"
-title: |-
+title: >-
   Caltrans Zero-Emission Bus Market Sounding Report
 asset: Caltrans.Zero.Emission.Bus.Market.Sounding.Report.pdf
 last_modified_at: 2025-11-03T08:00:00-08:00


### PR DESCRIPTION
closes #633

ref: https://stackoverflow.com/a/21699210/3019940 (via gemini)

## steps to test

1. compare the line breaks in the preview description to what is currently being served on production:
https://calitp.org/press/cal-itp-partners-celebrate-major-milestone-implementation-ods
https://deploy-preview-636--cal-itp-website.netlify.app/press/cal-itp-partners-celebrate-major-milestone-implementation-ods

    <img width="679" height="411" alt="Screenshot 2026-05-11 at 2 43 43 PM" src="https://github.com/user-attachments/assets/afd7859e-18c7-4909-883f-0ca1f18f5a2e" />

1. ensure that the whitespace in front-matter intros display identically in the pages themselves.

https://www.calitp.org/press/cal-itp-coast-rta-msa/
https://deploy-preview-636--cal-itp-website.netlify.app/press/cal-itp-coast-rta-msa/

<img width="1401" height="1015" alt="Screenshot 2026-05-11 at 2 48 54 PM" src="https://github.com/user-attachments/assets/490b6f75-e0c5-42e3-946e-f46e53319c23" />
