### PR TITLE
chore: add docs and github action for creating calendar versions

### DIFF
--- a/.cspell/dev-dictionary.txt
+++ b/.cspell/dev-dictionary.txt
@@ -78,6 +78,7 @@ shopify
 sissel
 smallcaps
 smartsymbols
+softprops
 stylesheet
 superfences
 toc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      # release tags
+      - "202[3-9].[0-9][0-9].[0-9]+"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      # https://github.com/softprops/action-gh-release#permissions
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          generate_release_notes: true

--- a/docs/guides/.pages
+++ b/docs/guides/.pages
@@ -1,0 +1,2 @@
+nav:
+  - Digital Services Design Language (DSDL): dsdl

--- a/docs/guides/dsdl/release.md
+++ b/docs/guides/dsdl/release.md
@@ -1,0 +1,23 @@
+# DSDL releases
+
+## Publishing a release
+
+The steps to create a release tag are identical to [Benefits](https://docs.calitp.org/benefits/guides/release/). Release candidate tags are skipped.
+
+## Consuming a release
+
+Referencing a specific [release](https://github.com/cal-itp/calitp.org/releases) via a link tag is recommended:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://raw.githubusercontent.com/cal-itp/calitp.org/refs/tags/2026.03.1/src/stylesheets/dsdl/dsdl.css"
+>
+```
+
+Loading bleeding-edge CSS (directly from [`main`](https://github.com/cal-itp/calitp.org/blob/main/src/stylesheets/dsdl/dsdl.css)) is _not_ recommended.
+
+```html
+<!-- don't do this -->
+<link rel="stylesheet" href="https://www.calitp.org/stylesheets/dsdl/dsdl.css">
+```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,1 +1,0 @@
-# Coming soon


### PR DESCRIPTION
this PR tackles the first two TODO:s in #613.

view it live: https://calitp-website-640--cal-itp-previews.netlify.app/guides/dsdl/release/