### PR TITLE
Chore: add instructions for expected handling of asset files

### DIFF
--- a/.github/workflows/resource-template.yml
+++ b/.github/workflows/resource-template.yml
@@ -59,7 +59,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Auto-PR for Resource Request #${{ steps.workflow_state.outputs.issue_number }}"
           draft: true
-          body: >
+          body: |-
             This PR is created automatically from a resource request. Please
             review the changes and merge when ready.
 

--- a/.github/workflows/resource-template.yml
+++ b/.github/workflows/resource-template.yml
@@ -63,6 +63,11 @@ jobs:
             This PR is created automatically from a resource request. Please
             review the changes and merge when ready.
 
+            Follow these steps to complete the resource creation.
+            1. Download the asset file
+            1. Add the downloaded file to the `src/assets/` directory'
+            1. Update the `asset` field in the created resource (above) to the filename of the newly added resource'
+
             Closes #${{ steps.workflow_state.outputs.issue_number }}
           add-paths: "src/resources/"
           commit-message: "feat: start resource for req #${{ steps.workflow_state.outputs.issue_number }}"


### PR DESCRIPTION
Closes #649 

In #566, there was some clarification needed on the latest guidance for how the asset file should be processed. Guidance was documented in https://github.com/cal-itp/calitp.org/pull/566#issuecomment-3921776652 and in the README via #575, but on the auto-created PRs themselves, it's not clear that this is the expectation.

This PR adds some steps to the generated PR description to help make it more obvious and reduce doubt / confusion.