### PR TITLE
Chore: add `editor.defaultFormatter` override for exhaustive list

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,29 @@
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
   "editor.tabSize": 2,
-  "[css][html][javascript][json][liquid][markdown][yaml]": {
+  // the declarations below take precedence over file specific formatters specified in *user* settings
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[liquid]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
Part of #654

Addresses the first item listed in the ticket.

Similar to https://github.com/cal-itp/mobility-marketplace/pull/912/changes/8737302ff1bdc8ee82ab0dde6bcfcf20cc0322d3 and https://github.com/compilerla/compiler.la/pull/300/changes/f9f27cbdc3f5edd073fa28ad1c2d6501b7ca5700