### PR TITLE
Chore: use same Liquid extension as other static site projects

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
         "esbenp.prettier-vscode",
         "mhutchie.git-graph",
         "redhat.vscode-xml",
-        "sissel.shopify-liquid",
+        "shopify.theme-check-vscode",
         "streetsidesoftware.code-spell-checker",
         "tombi-toml.tombi"
       ]


### PR DESCRIPTION
Closes #654 

Addresses the second item listed in the ticket.

MobiMart: 
https://github.com/cal-itp/mobility-marketplace/blob/cb4603856a7c575599407a8e5c98ac8396de3225/.devcontainer/devcontainer.json#L25

compiler.la: 
https://github.com/compilerla/compiler.la/blob/e717571f5b8263019926430d6f68d73a189add7a/.devcontainer/devcontainer.json#L25

(side note: why doesn't GitHub do the cool snippet preview thing anymore when you paste permalinks to lines of code? :frowning_face:)